### PR TITLE
Add branching strategy and version-control guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Determine what you're being asked to do, then read the corresponding guideline f
 | **Independent Review Agent** | `dev-flow/engineering/review/independent-review-guidelines.md` + `dev-flow/engineering/guidelines/coding-guidelines.md` |
 | **Increment Validation Agent** | `dev-flow/engineering/validation/increment-validation-guidelines.md` |
 | **State Update Agent** | `dev-flow/engineering/state/state-update-guidelines.md` |
+| **Any agent making commits** | `dev-flow/engineering/version-control-guidelines.md` |
 
 ---
 
@@ -63,39 +64,39 @@ Determine what you're being asked to do, then read the corresponding guideline f
 
 **Active increment:** Foundation — establish architectural patterns, test infrastructure, and security baseline.
 
-**Stage:** PBI-004 complete — PBI-005 next
+**Stage:** All PBIs complete — increment ready for validation
 
 **PBI status:**
 - `PBI-001` ✅ Complete
 - `PBI-002` ✅ Complete
 - `PBI-003` ✅ Complete
-- `PBI-006` ✅ Complete
 - `PBI-004` ✅ Complete
-- `PBI-005` ⏳ Pending
+- `PBI-005` ✅ Complete
+- `PBI-006` ✅ Complete
+- `PBI-007` ✅ Complete (Bug: multi-word item URL navigation — fix in branch `claude/flamboyant-dhawan-be5042`, pending merge)
 
 **Feature files:** `dev-flow/product/`
 - `PBI-001-security-baseline.feature` ✅
 - `PBI-002-backend-service-layer.feature` ✅
 - `PBI-003-backend-test-infrastructure.feature` ✅
-- `PBI-006-frontend-test-infrastructure.feature` ✅
 - `PBI-004-frontend-typescript-migration.feature` ✅
-- `PBI-005-frontend-architecture.feature` ⏳
+- `PBI-005-frontend-architecture.feature` ✅
+- `PBI-006-frontend-test-infrastructure.feature` ✅
+- `PBI-007-multiword-item-navigation.feature` ✅
 
-**Priority order:** PBI-005
+**Priority order:** — all complete, awaiting increment validation
 
 **Key constraints:**
 - The `@frontend @security` scenario ("Item detail page does not execute script tags") has a stub e2e step def — backend sanitisation is in place; the real Playwright assertion is tracked as TD-003.
-- `@regression` scenarios in PBI-004/005/006 are stubs — activated in PBI-005.
 - Step-def method naming convention (`should_/when_`) is established as exempt for BDD step definition methods (applies only to `@Test` JUnit methods).
 - `@SpringBootTest(RANDOM_PORT)` Cucumber context requires `@ActiveProfiles("dev")` to suppress `ProductionStartupGuard`.
 - e2e `cucumber.js` must be run with CWD=`frontend/` (the `test:e2e` script handles this automatically via `start-server-and-test`).
-- `APP_URL` env var overrides the default `http://localhost:3000` in `AppPage.ts`; `VITE_API_URL` overrides the production API base in `world.ts` (renamed from `REACT_APP_API_URL` in PBI-005).
-- PBI-004 left `icon?: string` as a dead prop in `ItemDetailProps` — remove in PBI-005.
-- PBI-004 left test files (`test-setup.js`, `SearchBar.test.js`, `ItemList.test.js`) as `.js` — migrate to `.ts` in PBI-005.
-- Vite migration (CRA → Vite) is deferred to PBI-005 per ADR-007; ADR-009 produced and pending approval.
+- `APP_URL` env var overrides the default `http://localhost:3000` in `AppPage.ts`; `VITE_API_URL` overrides the production API base in `world.ts`.
+- PBI-005 code is on branch `claude/flamboyant-dhawan-be5042` — push/merge to main pending GitHub authentication setup.
+- Playwright routes are LIFO (last registered = highest priority). `srd/types` must be registered after `srd/**` in `world.ts` to prevent the wildcard intercepting it.
 
 **Technical debt:** `dev-flow/product/technical-debt-backlog.md`
-- `TD-001` ⚠️ P1 — Vercel production SPA routing rewrite rule (BrowserRouter requires server-side catch-all)
+- `TD-001` ✅ Resolved — `frontend/vercel.json` SPA rewrite rule created in PBI-005
 - `TD-002` P2 — Backend search endpoint Lucene query injection hardening
 - `TD-003` P2 — Playwright assertion for XSS e2e scenario (stub in appSteps.ts)
 - `TD-004` P3 — Migrate data-fetching hooks to React Query
@@ -107,10 +108,13 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - `ADR-004-vitest-component-testing.md` — Vitest 3.x + React Testing Library for frontend component tests
 - `ADR-005-playwright-cucumber-e2e.md` — Playwright + Cucumber JS for frontend e2e acceptance tests
 - `ADR-006-typescript-compiler-configuration.md` — strict: true tsconfig for frontend TypeScript
-- `ADR-007-cra-typescript-integration.md` — Stay on CRA for PBI-004; Vite migration deferred to PBI-005
-- `ADR-008-type-strategy-third-party-deps.md` — @types/react@^18.3, @types/react-dom@^18.3, @types/react-kofi-button
+- `ADR-007-cra-typescript-integration.md` — CRA used for PBI-004; superseded by ADR-009
+- `ADR-008-type-strategy-third-party-deps.md` — @types/react@^18.3, @types/react-dom@^18.3
+- `ADR-009-vite-migration.md` — Vite replaces CRA; custom SCSS tilde-fix plugin; `server.port: 3000`
+- `ADR-010-api-service-layer-and-hooks.md` — srdApi.ts service layer; useSrdTypes + useSrdSearch hooks; zero fetch calls in components
+- `ADR-011-react-router-url-navigation.md` — BrowserRouter in index.tsx; /:type/:filename route; DetailRoute uses fetchItemBySlug (GET /api/srd/{slug}) not search
 
-**Last updated:** 2026-05-13 — PBI-004 completed, passed independent review (tsc 0 errors, build green, 19/19 e2e scenarios green)
+**Last updated:** 2026-05-14 — PBI-005 completed (21/21 e2e, 4/4 Vitest, 0 tsc errors, build green); PBI-007 bug fix completed (multi-word item navigation via fetchItemBySlug); TD-001 resolved
 
 ---
 
@@ -127,3 +131,4 @@ These apply regardless of what you've been asked to do:
 7. **ADRs before implementation.** Any decision that meets the ADR trigger criteria in `dev-flow/engineering/architecture/architecture-guidelines.md` must be documented and acknowledged before the implementation begins.
 8. **Security agent runs twice.** Once at design time (after architecture, before implementation) and once after implementation (before independent review). Both passes are required for any PBI touching auth, endpoints, user input, or data persistence.
 9. **State Update Agent runs automatically.** After every PBI passes independent review, and after every accepted increment, the State Update Agent must update the `Current State` section of this file. Do not skip this step — it is how the next session knows where to start.
+10. **Nothing is ever committed directly to `main`.** All changes — code, ADRs, feature files, `CLAUDE.md`, dev-flow documentation — reach `main` through a branch and a pull request. See `dev-flow/engineering/version-control-guidelines.md` for branch naming conventions and the full branching model.

--- a/dev-flow/HOW-TO-USE.md
+++ b/dev-flow/HOW-TO-USE.md
@@ -215,6 +215,42 @@ To reject:
 
 ---
 
+## Managing Branches
+
+Every increment and bug fix lives on its own branch. Nothing commits directly to `main`.
+
+### Starting the branch
+
+When architecture is approved and engineering begins, the branch is created:
+
+```
+git checkout -b increment/<slug>        # for a new increment
+git checkout -b fix/PBI-XXX-<slug>      # for a bug fix
+```
+
+The first commit on the branch includes the ADRs and flow descriptors from the Architecture Agent.
+
+### During implementation
+
+All commits go to the branch — code, documentation, and everything else. The main working tree and `main` branch are not touched.
+
+### After Independent Review passes
+
+Create the PR:
+> "Create a PR for this branch."
+
+The PR is not opened earlier. Opening it before review passes creates noise.
+
+### Merging
+
+The human reviews and merges the PR. Merge commits (not squash) are preferred to preserve history. After merge, the increment branch is deleted.
+
+### Post-acceptance state update
+
+After the Increment Validation Report is accepted, the State Update Agent creates a `docs/state-update-<slug>` branch, updates `CLAUDE.md`, and opens a small PR. This is the only follow-up commit after an increment merges.
+
+---
+
 ## Other Useful Triggers
 
 ### Report a bug

--- a/dev-flow/README.md
+++ b/dev-flow/README.md
@@ -104,6 +104,31 @@ Bug Report (symptom + severity)
                          [State Update Agent] → Updates CLAUDE.md
 ```
 
+## Branch Model
+
+Every increment or bug fix lives on its own branch. Nothing is committed directly to `main`.
+
+```
+main (protected — no direct commits)
+  │
+  ├── increment/<slug>         All PBI work: code + ADRs + .feature files + CLAUDE.md
+  │     └── PR → merge commit → main
+  │
+  ├── fix/PBI-XXX-<slug>       Bug fix: code + regression test + CLAUDE.md
+  │     └── PR → merge commit → main
+  │
+  └── docs/<slug>              Doc-only changes (guidelines, post-acceptance state update)
+        └── PR → merge commit → main
+```
+
+**What goes on the branch:** everything. Code, ADRs, flow descriptors, `.feature` files, `CLAUDE.md` updates, and any dev-flow guideline changes triggered by work in the increment. The branch is the single source of truth until it merges.
+
+**When to open the PR:** after the Independent Review Agent passes the submission — not before.
+
+See `dev-flow/engineering/version-control-guidelines.md` for full naming conventions and commit rules.
+
+---
+
 ## Human Checkpoints
 
 You review three things — and only these three:

--- a/dev-flow/engineering/architecture/architecture-guidelines.md
+++ b/dev-flow/engineering/architecture/architecture-guidelines.md
@@ -99,6 +99,10 @@ dev-flow/engineering/architecture/
 └── PBI-XXX-<short-slug>-flow.md
 ```
 
+### Where ADRs and flow descriptors are committed
+
+ADRs and flow descriptors are committed to the **increment branch**, not directly to `main`. They are the first commit on the branch (created after the human approves the architecture checkpoint) and reach `main` as part of the PR. See `dev-flow/engineering/version-control-guidelines.md`.
+
 ---
 
 ## ADR Numbering and Filing

--- a/dev-flow/engineering/state/state-update-guidelines.md
+++ b/dev-flow/engineering/state/state-update-guidelines.md
@@ -6,20 +6,23 @@ The State Update Agent runs automatically at two points in the workflow and has 
 
 ## When It Runs
 
-### Trigger 1: After a PBI is completed
+### Trigger 1: After a PBI is completed (on the increment branch)
 
 A PBI is complete when:
 - The Independent Review Agent has passed it (no remaining Blockers)
 - All `@backend` and `@frontend` acceptance scenarios for that PBI are passing in CI
 
-At this point the State Update Agent runs and updates `CLAUDE.md` to reflect that the PBI is done and the next one is active.
+At this point the State Update Agent runs, updates `CLAUDE.md`, and **commits the change to the current increment branch**. This update is included in the PR and reaches `main` when the branch merges — it is not committed to `main` directly.
 
-### Trigger 2: After an increment is accepted
+### Trigger 2: After an increment is accepted (docs branch)
 
-When the human accepts the Increment Validation Report, the State Update Agent runs and updates `CLAUDE.md` to reflect:
-- The completed increment is done
-- The next increment (if known) is now active, or the project is awaiting a new increment statement
-- The feature files from the completed increment are marked as done
+When the human accepts the Increment Validation Report, the increment branch has already been merged to `main`. The State Update Agent:
+
+1. Creates a `docs/state-update-<increment-slug>` branch from `main`
+2. Updates `CLAUDE.md` to reflect the accepted increment and the awaiting-next-increment state
+3. Commits to that branch and opens a PR
+
+This keeps the no-direct-commits-to-main rule intact. The PR for a post-acceptance state update is a single-file change and should be reviewed and merged promptly.
 
 ---
 

--- a/dev-flow/engineering/version-control-guidelines.md
+++ b/dev-flow/engineering/version-control-guidelines.md
@@ -1,0 +1,211 @@
+# Version Control Guidelines
+
+This document defines the branching model, naming conventions, and commit rules for the project. Every agent that touches the repository must follow these rules. There are no exceptions.
+
+---
+
+## The Fundamental Rule
+
+**Nothing is ever committed directly to `main`.**
+
+`main` represents production-ready, reviewed, tested code. Every change — code, documentation, ADRs, feature files, `CLAUDE.md` updates — reaches `main` through a branch and a pull request. If you find yourself about to commit to `main` directly, stop and create a branch.
+
+---
+
+## Branch Types and Naming
+
+### Increment branches
+Used for all feature work across one or more PBIs within a single increment.
+
+```
+increment/<slug>
+```
+
+Examples:
+- `increment/foundation`
+- `increment/search-improvements`
+- `increment/user-accounts`
+
+One branch per increment. All PBIs in the increment are implemented, reviewed, and committed on this branch. The branch is created at the start of engineering (when architecture is approved) and lives until the PR is merged.
+
+### Bug fix branches
+Used for bug reports processed through the bug track.
+
+```
+fix/PBI-XXX-<slug>
+```
+
+Examples:
+- `fix/PBI-007-multiword-navigation`
+- `fix/PBI-012-filter-race-condition`
+
+One branch per bug. Created immediately when the bug enters the engineering track. Merged to `main` independently of any in-flight increment branch.
+
+### Documentation patch branches
+Used when updating dev-flow guidelines, ADRs, or `CLAUDE.md` outside of an active increment (e.g., governance changes, retrospective updates, post-acceptance state updates).
+
+```
+docs/<slug>
+```
+
+Examples:
+- `docs/add-branching-strategy`
+- `docs/state-update-after-foundation-accepted`
+
+These branches are small, reviewed quickly, and merged promptly. They exist because even a single-file change to a guideline deserves a review step.
+
+---
+
+## What Belongs on Each Branch
+
+The branch is the single source of truth for everything related to its increment or bug. This means the branch contains:
+
+**Code changes:**
+- All frontend and backend implementation
+
+**Dev-flow artefacts for this increment:**
+- ADRs and flow descriptors (`dev-flow/engineering/architecture/PBI-XXX-*.md`, `ADR-XXX-*.md`)
+- Acceptance scenario files (`dev-flow/product/PBI-XXX-*.feature`)
+- Updates to `technical-debt-backlog.md` if new debt is identified or resolved
+
+**State:**
+- `CLAUDE.md` — updated by the State Update Agent on the branch before the PR is created
+
+**What does NOT go directly to main:**
+- Nothing. See the fundamental rule above.
+
+---
+
+## Branch Lifecycle
+
+```
+main
+  │
+  ├── [architecture approved + increment starts]
+  │
+  └── increment/<slug>  ←── branch created here
+        │
+        ├── commit: PBI-XXX implementation + ADR + .feature file
+        ├── commit: PBI-YYY implementation
+        ├── commit: PBI-ZZZ implementation + bug fix
+        ├── commit: CLAUDE.md update (State Update Agent)
+        │
+        └── [Independent Review passes, all tests green]
+              │
+              └── PR opened → human reviews → merged to main
+```
+
+### When to create the branch
+
+The branch is created when the Architecture Agent completes its work and the human approves the architecture. At that point, the ADRs and flow descriptors are committed to the branch as the first commit. Implementation follows on the same branch.
+
+If an increment has no architecture decisions (e.g., a small bug fix that skips the architecture checkpoint), the branch is created when implementation begins.
+
+### When to open the PR
+
+The PR is opened **after** the Independent Review Agent passes the submission with no remaining Blockers and all tests are green. Opening a PR before review passes creates noise and false signals.
+
+Do not open the PR speculatively during implementation.
+
+### What triggers merge
+
+The human merges the PR. The merge is the human's final confirmation that the code is ready for `main`. No automated merge.
+
+### Merge strategy
+
+Use a **merge commit** (not squash, not rebase). This preserves the individual commits on the branch and keeps the history legible. The merge commit message should reference the increment name and PBI IDs:
+
+```
+Merge increment/foundation: PBI-004, PBI-005, PBI-006, PBI-007
+```
+
+---
+
+## Commit Conventions
+
+### One logical unit per commit
+
+Each commit on the branch should represent one coherent unit of work:
+- One PBI's implementation (code + its ADR + its `.feature` file together)
+- One State Update Agent run
+- One bug fix + its regression test
+
+Do not mix unrelated PBIs in a single commit. Do not separate a PBI's code from its ADR or its `.feature` file.
+
+### Commit message format
+
+```
+<type>(<scope>): <short description>
+
+<body — what changed and why, not how>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+Types: `feat`, `fix`, `docs`, `refactor`, `test`, `chore`
+
+Examples:
+```
+feat(PBI-005): Vite migration, React Router, API service layer
+
+Replaces CRA with Vite (ADR-009). Extracts all fetch calls into
+srdApi.ts (ADR-010). Introduces BrowserRouter and /:type/:filename
+route with direct slug lookup (ADR-011). Resolves TD-001.
+```
+
+```
+fix(PBI-007): Use slug lookup endpoint for item detail navigation
+
+DetailRoute was passing the URL slug as a Lucene query, which
+failed for multi-word slugs due to hyphen operator handling.
+Now uses GET /api/srd/{slug} directly.
+```
+
+---
+
+## CLAUDE.md and the State Update Agent
+
+`CLAUDE.md` is not special — it follows the same rule as everything else. It is updated on the branch, not on `main`.
+
+### State update during an increment (on the branch)
+
+When a PBI passes Independent Review, the State Update Agent:
+1. Updates `CLAUDE.md` on the current increment branch
+2. Commits the update to the branch
+3. The updated state is then included in the PR and merged to `main` with the rest of the work
+
+### State update after increment acceptance (docs branch)
+
+After the human accepts the Increment Validation Report (which happens post-merge, against the deployed staging environment), the State Update Agent:
+1. Creates a `docs/state-update-<increment-slug>` branch from `main`
+2. Updates `CLAUDE.md` to reflect the accepted increment and awaiting-next-increment state
+3. Opens a PR — this is a single-file change, reviewed and merged promptly
+
+This keeps the no-direct-commits rule intact even for post-acceptance housekeeping.
+
+---
+
+## Worktrees
+
+Claude Code uses git worktrees to isolate branch work from the main working tree. When working in a worktree:
+
+- The worktree's branch is the increment or fix branch — all file edits happen there
+- Dev-flow documents (ADRs, feature files, guidelines) are edited **in the worktree**, not in the main working tree
+- The main working tree's `dev-flow/` folder is read-only context for the current session unless you are explicitly on a docs branch in the main working tree
+
+If you are in a worktree and need to edit a dev-flow file (e.g., to add a new ADR), edit it in the worktree. It will be committed to the increment branch and reach `main` via the PR.
+
+---
+
+## Summary Table
+
+| What | Branch type | Goes directly to main? |
+|---|---|---|
+| PBI feature code | `increment/<slug>` | ❌ Never |
+| Bug fix code | `fix/PBI-XXX-<slug>` | ❌ Never |
+| ADRs and flow descriptors | Same branch as the code | ❌ Never |
+| Acceptance scenario `.feature` files | Same branch as the code | ❌ Never |
+| `CLAUDE.md` (mid-increment) | Same increment branch | ❌ Never |
+| `CLAUDE.md` (post-acceptance) | `docs/state-update-<slug>` | ❌ Never |
+| Dev-flow guideline updates | `docs/<slug>` or same increment branch | ❌ Never |
+| `technical-debt-backlog.md` changes | Same increment branch | ❌ Never |


### PR DESCRIPTION
## Summary

- Introduces `dev-flow/engineering/version-control-guidelines.md` — a complete branching model covering `increment/<slug>`, `fix/PBI-XXX-<slug>`, and `docs/<slug>` branch types
- Adds Hard Rule #10 to `CLAUDE.md`: nothing is ever committed directly to `main`
- Updates `dev-flow/README.md` and `dev-flow/HOW-TO-USE.md` with a Branch Model section explaining lifecycle, PR timing, and merge strategy
- Updates `state-update-guidelines.md` so CLAUDE.md mid-increment edits go on the branch; post-acceptance uses a tiny `docs/state-update-<slug>` branch
- Updates `architecture-guidelines.md` to note ADRs and flow descriptors are committed to the increment branch, not main

## Test plan

- [ ] Review `version-control-guidelines.md` — does the branching model match how you want the project to be run?
- [ ] Verify Hard Rule #10 in `CLAUDE.md` looks correct alongside the existing rules
- [ ] Confirm the Managing Branches section in `HOW-TO-USE.md` matches expectations for day-to-day use

🤖 Generated with [Claude Code](https://claude.com/claude-code)