### PR TITLE
Add UX/Design Agent to dev-flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,16 +24,18 @@ All work on this project follows the process defined in `dev-flow/`. The short v
 
 1. **Product track** — increment is broken into PBIs → prioritised → acceptance scenarios written (`.feature` files in `dev-flow/product/`)
 2. **Human checkpoint** — human approves scenarios
-3. **Architecture** — ADRs and flow descriptors produced for each PBI
-4. **Human checkpoint** — human approves architecture
-5. **Implementation** — Frontend and backend agents implement against the approved design
-6. **Security review** — inline, two passes (design + implementation)
-7. **Testing** — Test agent writes step definitions from `.feature` files
-8. **Independent review** — separate agent reviews code against guidelines
-9. **Human checkpoint** — human reviews escalations only
-10. **State update** — State Update Agent rewrites `Current State` in this file
-11. **Validation** — increment validated against original intent
-12. **State update** — State Update Agent rewrites `Current State` in this file again after increment is accepted
+3. **Design** — Design Agent produces a Design Specification for any PBI with frontend scope (skipped for backend-only PBIs)
+4. **Human checkpoint** — human approves design before engineering begins
+5. **Architecture** — ADRs and flow descriptors produced for each PBI
+6. **Human checkpoint** — human approves architecture
+7. **Implementation** — Frontend and backend agents implement against the approved design and architecture
+8. **Security review** — inline, two passes (design + implementation)
+9. **Testing** — Test agent writes step definitions from `.feature` files
+10. **Independent review** — separate agent reviews code against guidelines
+11. **Human checkpoint** — human reviews escalations only
+12. **State update** — State Update Agent rewrites `Current State` in this file
+13. **Validation** — increment validated against original intent
+14. **State update** — State Update Agent rewrites `Current State` in this file again after increment is accepted
 
 **Read `dev-flow/HOW-TO-USE.md` if you need to understand how to trigger or navigate any stage.**
 
@@ -48,9 +50,10 @@ Determine what you're being asked to do, then read the corresponding guideline f
 | **Breakdown Agent** | `dev-flow/product/product-track-guidelines.md` |
 | **Prioritization Agent** | `dev-flow/product/product-track-guidelines.md` |
 | **Acceptance Scenario Agent** | `dev-flow/product/product-track-guidelines.md` + `dev-flow/product/acceptance-scenarios.md` |
+| **UX/Design Agent** | `dev-flow/design/ux-design-guidelines.md` |
 | **Architecture Agent** | `dev-flow/engineering/architecture/architecture-guidelines.md` |
 | **Implementation Agent (backend)** | `dev-flow/engineering/guidelines/coding-guidelines.md` + relevant accepted ADRs in `dev-flow/engineering/architecture/` |
-| **Implementation Agent (frontend)** | `dev-flow/engineering/guidelines/coding-guidelines.md` + relevant accepted ADRs in `dev-flow/engineering/architecture/` |
+| **Implementation Agent (frontend)** | `dev-flow/engineering/guidelines/coding-guidelines.md` + relevant accepted ADRs in `dev-flow/engineering/architecture/` + approved Design Specification in `dev-flow/design/` |
 | **Security Agent** | `dev-flow/engineering/security/security-agent-guidelines.md` |
 | **Test Implementation Agent** | `dev-flow/engineering/testing/testing-strategy.md` + the `.feature` file(s) for the PBI |
 | **Independent Review Agent** | `dev-flow/engineering/review/independent-review-guidelines.md` + `dev-flow/engineering/guidelines/coding-guidelines.md` |

--- a/dev-flow/HOW-TO-USE.md
+++ b/dev-flow/HOW-TO-USE.md
@@ -6,10 +6,11 @@ This is the practical guide for triggering and navigating the workflow day-to-da
 
 ## The Short Version
 
-You provide a goal. The agents handle the rest. You review three things:
+You provide a goal. The agents handle the rest. You review four things:
 1. The acceptance scenarios (before engineering starts)
-2. The architecture decisions (before implementation starts)
-3. The validation report (after delivery)
+2. The design specification (before architecture starts, frontend PBIs only)
+3. The architecture decisions (before implementation starts)
+4. The validation report (after delivery)
 
 Everything else — breakdown, prioritisation, implementation, testing, review, security — happens without you unless something needs a human decision.
 
@@ -149,9 +150,38 @@ To answer scenario gap questions:
 
 ## Navigating the Engineering Track
 
-Once scenarios are approved, engineering begins automatically. The Architecture Agent runs first, then implementation, then testing and review. You only re-enter at the architecture checkpoint.
+Once scenarios are approved, the Design Agent runs first (for any PBI with frontend scope), then architecture, then implementation, testing and review. You re-enter at the design checkpoint and the architecture checkpoint.
 
-### After the Architecture Agent — **Your second checkpoint**
+### After the Design Agent — **Your second checkpoint**
+
+You'll receive one Design Specification per PBI that has frontend scope. This is your chance to shape the user experience before any code is written.
+
+**What to look for:**
+- Does the layout and interaction model match what you intended?
+- Is the copy (button labels, error messages, headings) what you want users to see?
+- Are the loading, error, and empty states handled appropriately?
+- Do the design decisions and their rationale make sense to you?
+- Are there open design questions in the gap list you can answer now?
+
+**What to say:**
+
+To approve and proceed to architecture:
+> "Design approved, proceed to architecture."
+
+To request changes:
+> "On PBI-XXX: the search results should use a card layout, not a list. The empty state should mention the active type filter."
+
+To answer an open design question:
+> "On the gap list: use a spinner for loading states. The error message should include the search query."
+
+To request a change to copy:
+> "The 'Submit' button should say 'Search'. The empty state message should read 'No results for \"{query}\"'."
+
+Engineering does not begin until you approve the design for each frontend PBI. If you approve a partial design and ask the agent to hold on certain decisions, those open items must be resolved before the implementation agent picks up that PBI.
+
+---
+
+### After the Architecture Agent — **Your third checkpoint**
 
 You'll receive one or more ADRs and/or flow descriptors. Review these before implementation begins.
 
@@ -193,7 +223,7 @@ To override:
 
 ---
 
-### After the Increment Validation Agent — **Your third checkpoint**
+### After the Increment Validation Agent — **Your fourth checkpoint**
 
 You'll receive the validation report after the increment is deployed to staging. This is your product-level quality gate.
 

--- a/dev-flow/design/ux-design-guidelines.md
+++ b/dev-flow/design/ux-design-guidelines.md
@@ -1,0 +1,306 @@
+# UX/Design Agent Guidelines
+
+This document defines how the UX/Design Agent operates — when it runs, what it produces, how its output is structured, and what constitutes a valid design specification for handoff to the frontend engineer.
+
+---
+
+## Purpose
+
+The UX/Design Agent is responsible for translating approved acceptance scenarios into a concrete design specification that the frontend engineer can implement without ambiguity. It bridges the gap between "what the feature must do" (the `.feature` file) and "how the user interacts with it" (layout, components, states, interactions).
+
+The Design Agent does **not** write code. It produces design artefacts only.
+
+---
+
+## When the Design Agent Runs
+
+The Design Agent runs **after the Acceptance Scenario Agent** and **before the Architecture Agent**, but only for PBIs that have frontend or user interface scope.
+
+```
+[Human approves scenarios]
+         │
+         ▼
+ [Design Agent]  ← only for PBIs with @frontend or @e2e scenarios
+ Produces: Design Specification
+         │
+         ▼
+ 👤 Human checkpoint: approve design
+         │
+         ▼
+ [Architecture Agent]
+         │
+         ...
+```
+
+### PBIs that trigger the Design Agent
+
+A PBI triggers the Design Agent if it has **any** of the following:
+
+- Scenarios tagged `@frontend` or `@e2e`
+- A user story that describes an interaction (clicking, navigating, submitting a form, viewing a page)
+- Any new page, view, or UI component in its IN scope
+- Any change to an existing user-facing layout, interaction, or visual treatment
+
+### PBIs that skip the Design Agent
+
+- Pure backend PBIs (all scenarios tagged `@backend` only)
+- Infrastructure PBIs with no user-visible surface
+- Bug fixes that restore a previously approved design (the original spec is already the reference)
+
+When skipping, the Design Agent notes: `"Design stage skipped — no frontend scope in PBI-XXX."` and the Architecture Agent proceeds.
+
+---
+
+## What the Design Agent Receives
+
+- The approved `.feature` file(s) for the PBI
+- The current frontend codebase structure (to understand existing components, conventions, and design patterns already in use)
+- Any existing Design Specifications from previous increments (to maintain visual consistency)
+- The coding guidelines (`engineering/guidelines/coding-guidelines.md`) — specifically the frontend sections, to ensure the spec is implementable within the established component/hook/service model
+- Any relevant accepted ADRs that constrain the frontend (e.g., ADR-009 Vite migration, ADR-010 API service layer)
+
+The Design Agent does **not** receive implementation agent conversations, reasoning, or prior session context. It works from the artefacts only.
+
+---
+
+## What the Design Agent Produces
+
+One **Design Specification** per PBI, saved to:
+
+```
+dev-flow/design/
+└── PBI-XXX-<short-slug>-design.md
+```
+
+---
+
+## Design Specification Structure
+
+Every Design Specification uses the following format:
+
+```
+# Design Specification — PBI-XXX: [Feature Name]
+
+**PBI:** PBI-XXX
+**Design Agent output date:** YYYY-MM-DD
+**Status:** Draft | Approved | Superseded
+
+---
+
+## 1. Feature Summary
+
+[1–2 sentences: what the user can now do that they couldn't before, and how they experience it.]
+
+---
+
+## 2. Scope
+
+**IN scope for this design:**
+- [Visual surface or interaction covered by this spec]
+
+**OUT of scope:**
+- [Things not designed here — deferred, backend-only, or covered by a prior spec]
+
+---
+
+## 3. Pages and Routes Affected
+
+| Route | Page/Component | New or Modified |
+|---|---|---|
+| /path | PageName | New / Modified |
+
+---
+
+## 4. Component Inventory
+
+List every UI component needed for this PBI: new components to create, and existing components to modify.
+
+| Component | Status | Location | Responsibility |
+|---|---|---|---|
+| ComponentName | New / Modified | `src/features/x/ComponentName.tsx` | [What it renders and why] |
+
+---
+
+## 5. Layout and Visual Structure
+
+For each new page or significantly modified view, describe the layout using structured notation. Use ASCII wireframes for complex layouts; prose is acceptable for simple changes.
+
+### [View or Page Name]
+
+```
+┌─────────────────────────────────────────┐
+│  [Header / Navigation]                  │
+├─────────────────────────────────────────┤
+│  [Page Title]                           │
+│                                         │
+│  [Primary Content Area]                 │
+│    [Element 1]                          │
+│    [Element 2]                          │
+│                                         │
+│  [Secondary Content or Sidebar]         │
+└─────────────────────────────────────────┘
+```
+
+**Sizing and spacing notes:**
+- [Any grid, spacing, or breakpoint guidance]
+
+**Responsive behaviour:**
+- [How the layout adapts at smaller viewports, if applicable]
+
+---
+
+## 6. Interaction Specification
+
+For each user interaction in the feature (clicks, form submissions, navigation, loading states), define what happens.
+
+### [Interaction Name]
+
+**Trigger:** [What the user does — clicks a button, submits a form, navigates to a route]
+**Precondition:** [What state the UI must be in for this interaction to be available]
+**Outcome:** [What the user sees after the interaction completes]
+
+**States to design for:**
+
+| State | Visual treatment |
+|---|---|
+| Default | [Normal appearance] |
+| Loading | [Skeleton, spinner, disabled state — pick one and justify] |
+| Error | [Error message placement and copy] |
+| Empty | [What the user sees when there is no data] |
+| Success | [Confirmation treatment, if applicable] |
+
+---
+
+## 7. Copy and Labels
+
+All user-visible text that must appear exactly as written — button labels, headings, error messages, empty state copy, placeholder text. Where copy is flexible, note the constraint (e.g., "max 40 chars", "sentence case").
+
+| Element | Copy | Notes |
+|---|---|---|
+| Button | "Submit" | Sentence case |
+| Error message | "No results found for '{query}'" | Must include the query string |
+
+---
+
+## 8. Accessibility Notes
+
+Minimum requirements the implementation must meet for this feature:
+
+- Focus management: [Where focus lands after an interaction, if non-obvious]
+- ARIA labels: [Any non-visual elements that need labels]
+- Keyboard navigation: [Any interaction that must be keyboard-accessible]
+- Colour contrast: [Any new colours introduced must meet WCAG AA]
+
+---
+
+## 9. Design Decisions and Rationale
+
+Document any non-obvious design choice and the reasoning behind it. This section is the equivalent of an ADR for design — it lets the human review the "why" and challenge it before implementation.
+
+| Decision | Alternatives considered | Rationale |
+|---|---|---|
+| [What was decided] | [What else was considered] | [Why this choice] |
+
+---
+
+## 10. Open Design Questions
+
+Any aspect of the design that requires a product decision before the frontend engineer can implement it.
+
+```
+## Design Gap List — PBI-XXX
+
+The following design decisions cannot be resolved without a product choice:
+
+1. OPEN: [Question]
+   → Affects: [Which component or interaction]
+   → If unresolved, the implementation agent will need to make an assumption.
+
+2. OPEN: ...
+```
+
+If there are no open questions, state: "No open design questions."
+
+---
+
+## 11. Scenario Traceability
+
+Confirm that each `@frontend` and `@e2e` scenario in the `.feature` file is addressed by this spec.
+
+| Scenario | Addressed by |
+|---|---|
+| "User sees search results" | Section 5 — Search Results View; Section 6 — Loading/Error states |
+| "User navigates to item detail" | Section 3 — Routes; Section 6 — Navigation interaction |
+
+If a scenario is not covered, flag it here rather than silently omitting it.
+```
+
+---
+
+## Design Constraints
+
+The Design Agent must operate within the following constraints:
+
+### Visual consistency
+- Respect the existing visual language of the application — colour palette, typography, spacing scale, and component styles already in use. A redesign must be explicitly requested by the human; the Design Agent does not initiate one.
+- Reuse existing components wherever possible. Proposing a new component when an existing one can be modified adds unnecessary complexity.
+
+### Implementation feasibility
+- Designs must be implementable within the established component/hook/service architecture (ADR-010). A design that requires a component to fetch data directly is not a valid design spec — it must be restructured so a hook provides the data.
+- Designs must not introduce new external dependencies (new CSS libraries, new icon sets, new animation libraries) without flagging this explicitly in the Open Design Questions section. Any new dependency requires an ADR.
+
+### Scope discipline
+- The Design Agent designs only what is in the PBI's IN scope. It does not design adjacent improvements, enhancements to other features, or speculative future states unless explicitly asked.
+- If the Design Agent notices an adjacent UX issue while working, it surfaces it in a brief note rather than incorporating it into the spec: "Note: the existing search input has a related usability issue (no clear button) — this is out of scope for PBI-XXX but may be worth a future PBI."
+
+---
+
+## Human Checkpoint
+
+Once the Design Specification is produced, the human reviews it. This is the **design approval checkpoint**.
+
+**What you are approving:**
+- Does the layout and interaction model match what you intended when you described the feature?
+- Is the copy and labelling right?
+- Are the design decisions and rationale ones you agree with?
+- Are any open design questions ones you can answer now?
+
+**What you are not being asked to assess:**
+- Implementation correctness (that is the Review Agent's job)
+- Technical feasibility (that is the Architecture Agent's job)
+- Whether the tests cover the design (that is the Test Agent's job)
+
+**To approve and proceed to architecture:**
+> "Design approved, proceed to architecture."
+
+**To request changes:**
+> "On PBI-XXX: the search results should use a card layout, not a list. The empty state copy should mention the type filter specifically."
+
+**To answer an open design question:**
+> "On the gap list: use a spinner for loading states, not a skeleton. The error message should use the query string."
+
+The Architecture Agent does not begin until the Design Specification is approved. If architecture begins without an approved design spec for a frontend PBI, the Independent Review Agent treats this as a Blocker.
+
+---
+
+## What the Design Agent Does Not Do
+
+- It does not write CSS, SCSS, or any implementation code.
+- It does not make product decisions. If a scenario is ambiguous, it surfaces a question rather than resolving it silently.
+- It does not approve ADRs. That is the human's role.
+- It does not modify `.feature` files or acceptance scenarios.
+- It does not initiate a visual redesign of features outside the PBI's scope.
+- It does not produce high-fidelity mockups (no external tools, no image files). All artefacts are text-based and committed alongside other dev-flow documents.
+
+---
+
+## Updating an Approved Design
+
+If an approved Design Specification needs to change (e.g., the Architecture Agent identifies a constraint that makes a design element unimplementable, or the human requests a change mid-implementation), the Design Agent:
+
+1. Updates the specification file with the change.
+2. Updates the status field to `Draft`.
+3. Notes the change and the reason in the Design Decisions section.
+4. Resubmits for human approval.
+
+Implementation does not continue until the revised spec is re-approved.

--- a/dev-flow/engineering/review/independent-review-guidelines.md
+++ b/dev-flow/engineering/review/independent-review-guidelines.md
@@ -97,7 +97,17 @@ A Bug PBI submission that is missing a regression test is **always a Blocker**, 
 - Is no sensitive data logged, serialised into responses, or stored in insecure locations?
 - Does the submission introduce new attack surface (endpoints, integrations, trust boundaries) that is not documented and mitigated in an ADR?
 
-### 6. Architectural Consistency
+### 6. Design Specification Adherence (frontend PBIs only)
+
+For any PBI with `@frontend` or `@e2e` scenarios:
+- Is there an approved Design Specification in `dev-flow/design/PBI-XXX-*-design.md`?
+- Does the implementation match the layout, component inventory, and interaction specification in that document?
+- Are all states (loading, error, empty, success) implemented as specified?
+- Does the user-visible copy match what was approved (button labels, headings, error messages)?
+
+**Missing or unapproved Design Specification for a frontend PBI is a Blocker.** The implementation cannot be considered reviewable without it.
+
+### 7. Architectural Consistency
 - Does the submission introduce a new pattern not covered by an existing ADR?
 - Does the layer structure hold (controller → service → repository, component → hook → service)?
 - Are new dependencies (libraries, external services) introduced without an ADR?
@@ -167,6 +177,7 @@ Optional improvements — good engineering practice, not violations.
 | Scenarios covered by tests | ✅ All / ⚠ Partial / ❌ Missing |
 | Coding guidelines (Java) | ✅ Pass / ⚠ Warnings / ❌ Blockers |
 | Coding guidelines (React) | ✅ Pass / ⚠ Warnings / ❌ Blockers |
+| Design specification adherence | ✅ Pass / ⚠ Warnings / ❌ Blockers / N/A (backend-only) |
 | ADR adherence | ✅ Pass / ⚠ Warnings / ❌ Blockers |
 | Security | ✅ Pass / ⚠ Warnings / ❌ Blockers |
 | Architectural consistency | ✅ Pass / ⚠ Warnings / ❌ Blockers |


### PR DESCRIPTION
## Summary

- Introduces a new **UX/Design Agent** with full guidelines at `dev-flow/design/ux-design-guidelines.md`
- Adds a human-approved **design checkpoint** between scenario approval and architecture, for any PBI with frontend scope
- Backend-only PBIs skip the design stage automatically
- Updates `CLAUDE.md`, `HOW-TO-USE.md`, and `independent-review-guidelines.md` to wire the agent into the full workflow

## Test plan

- [ ] Review `dev-flow/design/ux-design-guidelines.md` — agent purpose, trigger conditions, Design Specification format, constraints, and human checkpoint instructions
- [ ] Verify `CLAUDE.md` workflow steps are correctly renumbered and the role table includes the UX/Design Agent
- [ ] Verify `HOW-TO-USE.md` now describes four checkpoints and includes the "After the Design Agent" section
- [ ] Verify `independent-review-guidelines.md` treats a missing design spec as a Blocker for frontend PBIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)