### PR TITLE
PBI-014, PBI-015, PBI-016: Visual improvements — trait width, slot gauges, full-width class feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,9 @@ Determine what you're being asked to do, then read the corresponding guideline f
 
 ## Current State
 
-**Active increment:** Character Sheet — five-section character sheet with SRD-backed pickers.
+**Active increment:** Character Sheet — visual improvements increment (PBI-013–016).
 
-**Stage:** PBI-012 complete — character sheet increment done; all foundation PBIs also complete
+**Stage:** PBI-013–016 complete — implementation, CSS, reducer logic, layout, and full e2e step definitions done; tsc 0 errors; pending PR merge.
 
 **PBI status:**
 - `PBI-001` ✅ Complete
@@ -76,12 +76,16 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - `PBI-004` ✅ Complete
 - `PBI-005` ✅ Complete
 - `PBI-006` ✅ Complete
-- `PBI-007` ✅ Complete (Bug: multi-word item URL navigation — fix in branch `claude/flamboyant-dhawan-be5042`, pending merge)
+- `PBI-007` ✅ Complete
 - `PBI-008` ✅ Complete
 - `PBI-009` ✅ Complete
 - `PBI-010` ✅ Complete
 - `PBI-011` ✅ Complete
 - `PBI-012` ✅ Complete
+- `PBI-013` ✅ Complete — character sheet styles and styled nav link (branch `increment/character-sheet-improvements`, merged into increment)
+- `PBI-014` ✅ Complete — trait score input width widened to prevent clipping
+- `PBI-015` ✅ Complete — slot trackers fill/empty as sequential gauges via `gaugeToggle`
+- `PBI-016` ✅ Complete — Class Feature section moved below two-column grid for full width
 
 **Feature files:** `dev-flow/product/`
 - `PBI-001-security-baseline.feature` ✅
@@ -96,21 +100,27 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - `PBI-010-character-sheet-traits-defence.feature` ✅
 - `PBI-011-character-sheet-health-hope-gold.feature` ✅
 - `PBI-012-character-sheet-weapons-armor.feature` ✅
+- `PBI-013-character-sheet-styles.feature` ✅
+- `PBI-014-trait-input-width.feature` ✅
+- `PBI-015-slot-tracker-gauge-behaviour.feature` ✅
+- `PBI-016-class-feature-full-width.feature` ✅
 
-**Priority order:** — all complete, awaiting increment validation
+**Priority order:** — awaiting increment validation
 
 **Key constraints:**
 - Step-def method naming convention (`should_/when_`) is established as exempt for BDD step definition methods (applies only to `@Test` JUnit methods).
 - `@SpringBootTest(RANDOM_PORT)` Cucumber context requires `@ActiveProfiles("dev")` to suppress `ProductionStartupGuard`.
 - e2e `cucumber.js` must be run with CWD=`frontend/` (the `test:e2e` script handles this automatically via `start-server-and-test`).
 - `APP_URL` env var overrides the default `http://localhost:3000` in `AppPage.ts`; `VITE_API_URL` overrides the production API base in `world.ts`.
-- PBI-005/007 code is on branch `claude/flamboyant-dhawan-be5042` — push/merge to main pending GitHub authentication setup.
 - Playwright routes are LIFO (last registered = highest priority). `srd/types` must be registered after `srd/**` in `world.ts` to prevent the wildcard intercepting it.
 - Character sheet: all 18 SUBCLASSES items in `srd.json` are tagged `["class:<slug>"]`; client-side filtering in `useSrdSubclasses` by `classSlug`.
 - Character sheet: WEAPONS and ARMOR SRD items use HTML content (not JSON strings as originally specified in ADR-013 draft); `useSrdWeapons` and `useSrdArmor` parse via regex. ADR-013 amended and approved.
 - Character sheet: `dangerouslySetInnerHTML` used only in `ClassFeatureSection` and `HopeSection` for backend-sanitised SRD content (ADR-002). The `extractHopeFeatureHtml` util carries a `⚠️ SECURITY` JSDoc.
 - Character sheet: shared API URL constant lives in `src/features/character-sheet/constants.ts` — all five SRD hooks import `CHARACTER_SHEET_API_URL` from there.
 - XSS e2e scenario (PBI-009 `@security @frontend`): real Playwright `page.on('dialog', ...)` assertion in place — TD-003 resolved.
+- Slot gauges: `gaugeToggle(slots, index)` in `CharacterContext.tsx` handles fill-right/empty-right for HP, stress, hope, armor, and proficiency. Clicking slot N fills 0..N; clicking the last-filled slot empties it.
+- AppPage.ts `clickSlot(testId)` takes a full test ID string; `areSlotsMarkedInRange(prefix, from, to)` builds IDs as `${prefix}-${i}`. Armor slots are 0-indexed in the DOM (`armor-slot-0` = slot 1); use `clickArmorSlot(n)` / `isArmorSlotMarked(n)` which handle the offset.
+- Version control: all work happens on `increment/<slug>` or `fix/PBI-XXX-<slug>` branches in the main working tree. No git worktrees (removed from guidelines 2026-05-14).
 
 **Technical debt:** `dev-flow/product/technical-debt-backlog.md`
 - `TD-001` ✅ Resolved — `frontend/vercel.json` SPA rewrite rule created in PBI-005
@@ -133,7 +143,7 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - `ADR-012-character-sheet-state-management.md` — React Context + useReducer scoped to character-sheet feature; approved 2026-05-14
 - `ADR-013-weapon-armor-srd-item-types.md` — WEAPONS/ARMOR as structured SrdItem types in srd.json; HTML-parsing amendment approved 2026-05-14
 
-**Last updated:** 2026-05-14 — PBI-008 through PBI-012 completed, passed independent review; tsc 0 errors; all @frontend and @security step definitions in place; ADR-012 and ADR-013 accepted
+**Last updated:** 2026-05-14 — PBI-013–016 implemented and tested; tsc 0 errors; all @frontend step definitions in place; increment on `increment/character-sheet-improvements`, PR pending merge
 
 ---
 

--- a/dev-flow/product/PBI-014-trait-input-width.feature
+++ b/dev-flow/product/PBI-014-trait-input-width.feature
@@ -1,0 +1,17 @@
+Feature: Trait Score Input Width
+  The trait score number inputs must be wide enough to display any valid
+  Daggerheart trait value, including negative numbers, without clipping.
+  Backlog item: PBI-014
+
+  Background:
+    Given the user navigates to the character sheet page
+
+  @regression @bug-PBI-014 @frontend
+  Scenario: Negative trait score displays without clipping
+    When the user enters "-2" in the "Agility" trait score field
+    Then the "Agility" trait score field displays the value "-2" without truncation
+
+  @regression @bug-PBI-014 @frontend
+  Scenario: Two-digit positive trait score displays fully
+    When the user enters "10" in the "Strength" trait score field
+    Then the "Strength" trait score field displays the value "10" without truncation

--- a/dev-flow/product/PBI-015-slot-tracker-gauge-behaviour.feature
+++ b/dev-flow/product/PBI-015-slot-tracker-gauge-behaviour.feature
@@ -1,0 +1,90 @@
+Feature: Slot Tracker Gauge Behaviour
+  HP, stress, hope diamond, armor, and proficiency slot trackers must
+  fill from left to right and empty from right to left when clicked,
+  matching the physical Daggerheart character sheet gauge metaphor.
+  Backlog item: PBI-015
+
+  Background:
+    Given the user navigates to the character sheet page
+
+  # ── HP tracker ────────────────────────────────────────────────────────
+
+  @regression @frontend
+  Scenario: Clicking an empty HP slot fills all slots up to and including it
+    When the user clicks HP slot 4
+    Then HP slots 1 through 4 are marked
+    And HP slots 5 through 10 are unmarked
+
+  @regression @frontend
+  Scenario: Clicking the last filled HP slot empties it
+    Given HP slots 1 through 3 are marked
+    When the user clicks HP slot 3
+    Then HP slots 1 through 2 are marked
+    And HP slot 3 is unmarked
+
+  @regression @frontend
+  Scenario: Clicking an earlier filled HP slot empties from that slot rightward
+    Given HP slots 1 through 5 are marked
+    When the user clicks HP slot 3
+    Then HP slots 1 through 2 are marked
+    And HP slots 3 through 10 are unmarked
+
+  # ── Stress tracker ────────────────────────────────────────────────────
+
+  @regression @frontend
+  Scenario: Clicking an empty stress slot fills all slots up to and including it
+    When the user clicks stress slot 3
+    Then stress slots 1 through 3 are marked
+    And stress slots 4 through 8 are unmarked
+
+  @regression @frontend
+  Scenario: Clicking the last filled stress slot empties it
+    Given stress slots 1 through 4 are marked
+    When the user clicks stress slot 4
+    Then stress slots 1 through 3 are marked
+    And stress slot 4 is unmarked
+
+  # ── Hope diamonds ─────────────────────────────────────────────────────
+
+  @regression @frontend
+  Scenario: Clicking an empty hope diamond fills all diamonds up to and including it
+    When the user clicks hope diamond 3
+    Then hope diamonds 1 through 3 are marked
+    And hope diamonds 4 through 6 are unmarked
+
+  @regression @frontend
+  Scenario: Clicking the last filled hope diamond empties it
+    Given hope diamonds 1 through 2 are marked
+    When the user clicks hope diamond 2
+    Then hope diamond 1 is marked
+    And hope diamond 2 is unmarked
+
+  # ── Armor slots ───────────────────────────────────────────────────────
+
+  @regression @frontend
+  Scenario: Clicking an empty armor slot fills all slots up to and including it
+    When the user clicks armor slot 3
+    Then armor slots 1 through 3 are marked
+    And armor slots 4 through 6 are unmarked
+
+  @regression @frontend
+  Scenario: Clicking the last filled armor slot empties it
+    Given armor slots 1 through 4 are marked
+    When the user clicks armor slot 4
+    Then armor slots 1 through 3 are marked
+    And armor slot 4 is unmarked
+
+  # ── Proficiency pips ──────────────────────────────────────────────────
+
+  @regression @frontend
+  Scenario: Clicking an empty proficiency pip fills all pips up to and including it
+    When the user clicks proficiency pip 4
+    Then proficiency pips 1 through 4 are filled
+    And proficiency pips 5 through 6 are unfilled
+
+  @regression @frontend
+  Scenario: Clicking the last filled proficiency pip empties it
+    Given proficiency pips 1 through 3 are filled
+    When the user clicks proficiency pip 3
+    Then proficiency pips 1 through 2 are filled
+    And proficiency pip 3 is unfilled

--- a/dev-flow/product/PBI-016-class-feature-full-width.feature
+++ b/dev-flow/product/PBI-016-class-feature-full-width.feature
@@ -1,0 +1,19 @@
+Feature: Class Feature Section Full Width
+  The Class Feature section must span the full width of the character
+  sheet (both columns) so that text-heavy class feature content is
+  readable and not cramped into a single narrow column.
+  Backlog item: PBI-016
+
+  Background:
+    Given the user navigates to the character sheet page
+
+  @regression @frontend
+  Scenario: Class Feature section spans the full width of the character sheet
+    When the user views the character sheet page
+    Then the Class Feature section spans both columns
+
+  @regression @frontend
+  Scenario: Class Feature section renders full-width in dark mode
+    Given the user has enabled dark mode
+    When they navigate to the character sheet page
+    Then the Class Feature section spans both columns

--- a/frontend/e2e/pages/AppPage.ts
+++ b/frontend/e2e/pages/AppPage.ts
@@ -590,6 +590,61 @@ export class AppPage {
     }
 
     // =============================================================================
+    // Slot gauge helpers (PBI-015)
+    // =============================================================================
+
+    /** Returns true if every slot in [from, to] has aria-pressed="true". Uses testId prefix, e.g. 'hp-slot'. */
+    async areSlotsMarkedInRange(testIdPrefix: string, from: number, to: number): Promise<boolean> {
+        for (let i = from; i <= to; i++) {
+            if (!(await this.isSlotMarked(`${testIdPrefix}-${i}`))) return false;
+        }
+        return true;
+    }
+
+    /** Returns true if every slot in [from, to] has aria-pressed != "true". Uses testId prefix. */
+    async areSlotsUnmarkedInRange(testIdPrefix: string, from: number, to: number): Promise<boolean> {
+        for (let i = from; i <= to; i++) {
+            if (await this.isSlotMarked(`${testIdPrefix}-${i}`)) return false;
+        }
+        return true;
+    }
+
+    /** Fill all slots up to slotNumber using gauge behaviour (clicking slot N fills 0..N). */
+    async fillSlotsUpTo(testIdPrefix: string, slotNumber: number): Promise<void> {
+        await this.clickSlot(`${testIdPrefix}-${slotNumber}`);
+    }
+
+    // =============================================================================
+    // Trait input helpers (PBI-014)
+    // =============================================================================
+
+    /** Returns true if the trait score input content is horizontally clipped. */
+    async isTraitScoreInputTruncated(traitKey: string): Promise<boolean> {
+        const input = this.page.locator(`[data-testid="trait-score-${traitKey}"]`);
+        await input.waitFor({ timeout: 5000 });
+        return input.evaluate((el: Element) => {
+            const inp = el as HTMLInputElement;
+            return inp.scrollWidth > inp.clientWidth;
+        });
+    }
+
+    // =============================================================================
+    // Layout helpers (PBI-016)
+    // =============================================================================
+
+    async classFeatureSectionSpansBothColumns(): Promise<boolean> {
+        const sheet = await this.page.$('[data-testid="character-sheet"]');
+        const section = await this.page.$('[data-testid="class-feature-section"]');
+        if (sheet === null || section === null) return false;
+        const sheetBox = await sheet.boundingBox();
+        const sectionBox = await section.boundingBox();
+        if (sheetBox === null || sectionBox === null) return false;
+        // The section width should be close to the sheet container width
+        // (within 60px to account for padding)
+        return Math.abs(sectionBox.width - sheetBox.width) < 60;
+    }
+
+    // =============================================================================
     // Style assertion helpers (PBI-013)
     // =============================================================================
 

--- a/frontend/e2e/steps/appSteps.ts
+++ b/frontend/e2e/steps/appSteps.ts
@@ -1163,3 +1163,209 @@ Then('the section headings have a gold text colour', async function (this: Custo
     // #ffd166 → rgb(255, 209, 102)
     expect(color).toBe('rgb(255, 209, 102)');
 });
+
+// =============================================================================
+// Shared background step (PBI-014, PBI-015, PBI-016)
+// =============================================================================
+
+Given('the user navigates to the character sheet page', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    await appPage.navigateToCharacterSheet();
+    await appPage.waitForCharacterSheet();
+});
+
+// =============================================================================
+// PBI-014 — Trait Score Input Width (regression)
+// =============================================================================
+
+Then('the {string} trait score field displays the value {string} without truncation', async function (
+    this: CustomWorld,
+    traitLabel: string,
+    expectedValue: string,
+) {
+    const appPage = new AppPage(this.page);
+    const traitKey = traitLabel.toLowerCase();
+    const actual = await appPage.getTraitScoreValue(traitKey);
+    expect(actual).toBe(expectedValue);
+    const truncated = await appPage.isTraitScoreInputTruncated(traitKey);
+    expect(truncated).toBe(false);
+});
+
+// =============================================================================
+// PBI-015 — Slot Tracker Gauge Behaviour
+// =============================================================================
+
+// ── Given: pre-fill gauge to a range ──────────────────────────────────────
+
+Given('HP slots {int} through {int} are marked', async function (this: CustomWorld, _from: number, to: number) {
+    // Gauge fill: clicking slot `to` fills all slots 1..to
+    const appPage = new AppPage(this.page);
+    await appPage.clickSlot(`hp-slot-${to}`);
+});
+
+Given('stress slots {int} through {int} are marked', async function (this: CustomWorld, _from: number, to: number) {
+    const appPage = new AppPage(this.page);
+    await appPage.clickSlot(`stress-slot-${to}`);
+});
+
+Given('hope diamonds {int} through {int} are marked', async function (this: CustomWorld, _from: number, to: number) {
+    const appPage = new AppPage(this.page);
+    await appPage.clickHopeDiamond(to);
+});
+
+Given('armor slots {int} through {int} are marked', async function (this: CustomWorld, _from: number, to: number) {
+    const appPage = new AppPage(this.page);
+    await appPage.clickArmorSlot(to);
+});
+
+Given('proficiency pips {int} through {int} are filled', async function (this: CustomWorld, _from: number, to: number) {
+    const appPage = new AppPage(this.page);
+    await appPage.clickProficiencyPip(to);
+});
+
+// ── When: click a specific slot ────────────────────────────────────────────
+
+When('the user clicks HP slot {int}', async function (this: CustomWorld, slotNumber: number) {
+    const appPage = new AppPage(this.page);
+    await appPage.clickSlot(`hp-slot-${slotNumber}`);
+});
+
+When('the user clicks stress slot {int}', async function (this: CustomWorld, slotNumber: number) {
+    const appPage = new AppPage(this.page);
+    await appPage.clickSlot(`stress-slot-${slotNumber}`);
+});
+
+When('the user clicks hope diamond {int}', async function (this: CustomWorld, diamondNumber: number) {
+    const appPage = new AppPage(this.page);
+    await appPage.clickHopeDiamond(diamondNumber);
+});
+
+When('the user clicks armor slot {int}', async function (this: CustomWorld, slotNumber: number) {
+    const appPage = new AppPage(this.page);
+    await appPage.clickArmorSlot(slotNumber);
+});
+
+When('the user clicks proficiency pip {int}', async function (this: CustomWorld, pipNumber: number) {
+    const appPage = new AppPage(this.page);
+    await appPage.clickProficiencyPip(pipNumber);
+});
+
+// ── Then: HP range assertions ──────────────────────────────────────────────
+
+Then('HP slots {int} through {int} are marked', async function (this: CustomWorld, from: number, to: number) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.areSlotsMarkedInRange('hp-slot', from, to)).toBe(true);
+});
+
+Then('HP slots {int} through {int} are unmarked', async function (this: CustomWorld, from: number, to: number) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.areSlotsUnmarkedInRange('hp-slot', from, to)).toBe(true);
+});
+
+Then('HP slot {int} is unmarked', async function (this: CustomWorld, slotNumber: number) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.isSlotMarked(`hp-slot-${slotNumber}`)).toBe(false);
+});
+
+// ── Then: Stress range assertions ──────────────────────────────────────────
+
+Then('stress slots {int} through {int} are marked', async function (this: CustomWorld, from: number, to: number) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.areSlotsMarkedInRange('stress-slot', from, to)).toBe(true);
+});
+
+Then('stress slots {int} through {int} are unmarked', async function (this: CustomWorld, from: number, to: number) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.areSlotsUnmarkedInRange('stress-slot', from, to)).toBe(true);
+});
+
+Then('stress slot {int} is unmarked', async function (this: CustomWorld, slotNumber: number) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.isSlotMarked(`stress-slot-${slotNumber}`)).toBe(false);
+});
+
+// ── Then: Hope diamond range assertions ────────────────────────────────────
+
+Then('hope diamonds {int} through {int} are marked', async function (this: CustomWorld, from: number, to: number) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.areSlotsMarkedInRange('hope-diamond', from, to)).toBe(true);
+});
+
+Then('hope diamonds {int} through {int} are unmarked', async function (this: CustomWorld, from: number, to: number) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.areSlotsUnmarkedInRange('hope-diamond', from, to)).toBe(true);
+});
+
+Then('hope diamond {int} is unmarked', async function (this: CustomWorld, diamondNumber: number) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.isHopeDiamondMarked(diamondNumber)).toBe(false);
+});
+
+// ── Then: Armor slot range assertions ──────────────────────────────────────
+
+Then('armor slots {int} through {int} are marked', async function (this: CustomWorld, from: number, to: number) {
+    const appPage = new AppPage(this.page);
+    for (let i = from; i <= to; i++) {
+        expect(await appPage.isArmorSlotMarked(i)).toBe(true);
+    }
+});
+
+Then('armor slots {int} through {int} are unmarked', async function (this: CustomWorld, from: number, to: number) {
+    const appPage = new AppPage(this.page);
+    for (let i = from; i <= to; i++) {
+        expect(await appPage.isArmorSlotMarked(i)).toBe(false);
+    }
+});
+
+Then('armor slot {int} is unmarked', async function (this: CustomWorld, slotNumber: number) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.isArmorSlotMarked(slotNumber)).toBe(false);
+});
+
+// ── Then: Proficiency pip range assertions ─────────────────────────────────
+
+Then('proficiency pips {int} through {int} are filled', async function (this: CustomWorld, from: number, to: number) {
+    const appPage = new AppPage(this.page);
+    for (let i = from; i <= to; i++) {
+        expect(await appPage.isProficiencyPipFilled(i)).toBe(true);
+    }
+});
+
+Then('proficiency pips {int} through {int} are unfilled', async function (this: CustomWorld, from: number, to: number) {
+    const appPage = new AppPage(this.page);
+    for (let i = from; i <= to; i++) {
+        expect(await appPage.isProficiencyPipFilled(i)).toBe(false);
+    }
+});
+
+Then('proficiency pip {int} is unfilled', async function (this: CustomWorld, pipNumber: number) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.isProficiencyPipFilled(pipNumber)).toBe(false);
+});
+
+// =============================================================================
+// PBI-016 — Class Feature Section Full Width
+// =============================================================================
+
+When('the user views the character sheet page', async function (this: CustomWorld) {
+    // No-op: already on the character sheet page from the Background step
+});
+
+Given('the user has enabled dark mode', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    const isDark = await appPage.isDarkModeActive();
+    if (!isDark) {
+        await appPage.enableDarkMode();
+    }
+});
+
+When('they navigate to the character sheet page', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    await appPage.navigateToCharacterSheet();
+    await appPage.waitForCharacterSheet();
+});
+
+Then('the Class Feature section spans both columns', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.classFeatureSectionSpansBothColumns()).toBe(true);
+});

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -930,7 +930,7 @@ main {
 }
 
 .traits-section__score-input {
-  width: 3rem !important;
+  width: 4.5rem !important;
   text-align: center;
   font-size: 1.1rem !important;
   font-weight: 700;

--- a/frontend/src/features/character-sheet/components/CharacterSheetPage.tsx
+++ b/frontend/src/features/character-sheet/components/CharacterSheetPage.tsx
@@ -26,7 +26,6 @@ function CharacterSheetPageInner(): React.ReactElement {
           <HopeSection />
           <ExperienceSection />
           <GoldSection />
-          <ClassFeatureSection />
         </div>
         <div className="character-sheet__column character-sheet__column--right" data-testid="right-column">
           <ActiveWeaponsSection />
@@ -34,6 +33,8 @@ function CharacterSheetPageInner(): React.ReactElement {
           <InventorySection />
         </div>
       </div>
+      {/* Class Feature spans full width below the two-column grid (PBI-016) */}
+      <ClassFeatureSection />
     </div>
   );
 }

--- a/frontend/src/features/character-sheet/context/CharacterContext.tsx
+++ b/frontend/src/features/character-sheet/context/CharacterContext.tsx
@@ -40,6 +40,20 @@ const initialState: CharacterState = {
   ],
 };
 
+/**
+ * Gauge fill helper — clicking slot at `index` (0-based) on an array of booleans:
+ *   - If index >= current filled count → fill all slots 0..index (extend right)
+ *   - If index <  current filled count → fill all slots 0..index-1 (retract from right)
+ *
+ * This matches the physical Daggerheart sheet where trackers fill left→right
+ * and empty right→left. Identical to the gold section pattern.
+ */
+function gaugeToggle(slots: boolean[], index: number): boolean[] {
+  const filled = slots.filter(Boolean).length;
+  const newCount = index + 1 > filled ? index + 1 : index;
+  return slots.map((_, i) => i < newCount);
+}
+
 function characterReducer(state: CharacterState, action: CharacterAction): CharacterState {
   switch (action.type) {
     case 'SET_IDENTITY':
@@ -57,12 +71,8 @@ function characterReducer(state: CharacterState, action: CharacterAction): Chara
     case 'SET_ARMOR_SCORE':
       return { ...state, armorScore: action.payload };
 
-    case 'TOGGLE_ARMOR_SLOT': {
-      const armorSlots = state.armorSlots.map((slot, i) =>
-        i === action.payload ? !slot : slot
-      );
-      return { ...state, armorSlots };
-    }
+    case 'TOGGLE_ARMOR_SLOT':
+      return { ...state, armorSlots: gaugeToggle(state.armorSlots, action.payload) };
 
     case 'SET_DAMAGE_THRESHOLD':
       return {
@@ -70,33 +80,17 @@ function characterReducer(state: CharacterState, action: CharacterAction): Chara
         damageThresholds: { ...state.damageThresholds, [action.payload.key]: action.payload.value },
       };
 
-    case 'TOGGLE_HP_SLOT': {
-      const hpSlots = state.hpSlots.map((slot, i) =>
-        i === action.payload ? !slot : slot
-      );
-      return { ...state, hpSlots };
-    }
+    case 'TOGGLE_HP_SLOT':
+      return { ...state, hpSlots: gaugeToggle(state.hpSlots, action.payload) };
 
-    case 'TOGGLE_STRESS_SLOT': {
-      const stressSlots = state.stressSlots.map((slot, i) =>
-        i === action.payload ? !slot : slot
-      );
-      return { ...state, stressSlots };
-    }
+    case 'TOGGLE_STRESS_SLOT':
+      return { ...state, stressSlots: gaugeToggle(state.stressSlots, action.payload) };
 
-    case 'TOGGLE_HOPE_DIAMOND': {
-      const hopeDiamonds = state.hopeDiamonds.map((diamond, i) =>
-        i === action.payload ? !diamond : diamond
-      );
-      return { ...state, hopeDiamonds };
-    }
+    case 'TOGGLE_HOPE_DIAMOND':
+      return { ...state, hopeDiamonds: gaugeToggle(state.hopeDiamonds, action.payload) };
 
-    case 'TOGGLE_PROFICIENCY_PIP': {
-      const proficiencyPips = state.proficiencyPips.map((pip, i) =>
-        i === action.payload ? !pip : pip
-      );
-      return { ...state, proficiencyPips };
-    }
+    case 'TOGGLE_PROFICIENCY_PIP':
+      return { ...state, proficiencyPips: gaugeToggle(state.proficiencyPips, action.payload) };
 
     case 'SET_EXPERIENCE': {
       const experience = state.experience.map((entry, i) =>


### PR DESCRIPTION
## Summary

- **PBI-014**: Widened trait score number inputs from `3rem` to `4.5rem` so negative values (e.g. `-2`) and two-digit values display without clipping
- **PBI-015**: Slot trackers (HP, stress, hope diamonds, armor, proficiency) now fill left→right and empty right→left as sequential gauges, matching the physical Daggerheart sheet; implemented via shared `gaugeToggle` helper in `CharacterContext.tsx`
- **PBI-016**: Class Feature section moved outside the two-column grid so it spans the full sheet width, making long text more readable

## Commits

- `docs(PBI-014–016)`: acceptance scenario feature files
- `fix(PBI-014)`: trait input width fix (3rem → 4.5rem)
- `feat(PBI-015)`: gaugeToggle reducer + all five tracker cases (HP, stress, hope, armor, proficiency)
- `feat(PBI-016)`: ClassFeatureSection repositioned below the columns div
- `test(PBI-014–016)`: AppPage range helpers + 206 lines of new e2e step definitions
- `docs(state)`: CLAUDE.md updated

## Test plan

- [ ] `npx tsc --noEmit` passes (0 errors)
- [ ] PBI-014 `@regression @bug-PBI-014 @frontend` scenarios: negative and two-digit trait values display without truncation
- [ ] PBI-015 `@regression @frontend` scenarios: HP/stress/hope/armor/proficiency fill and empty correctly (gauge left→right / right→left)
- [ ] PBI-016 `@regression @frontend` scenarios: Class Feature spans both columns in light and dark mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)