### PR TITLE
feat: PBI-017/018/019 — class HP count, domain badges fix, experience fields

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,9 @@ Determine what you're being asked to do, then read the corresponding guideline f
 
 ## Current State
 
-**Active increment:** Character Sheet — visual improvements increment (PBI-013–016).
+**Active increment:** Character Sheet — class HP count, domain badges fix, experience fields (PBI-017–019).
 
-**Stage:** PBI-013–016 complete — implementation, CSS, reducer logic, layout, and full e2e step definitions done; tsc 0 errors; pending PR merge.
+**Stage:** PBI-017–019 complete — implementation, tests, and e2e step definitions done; pending PR merge.
 
 **PBI status:**
 - `PBI-001` ✅ Complete
@@ -82,10 +82,13 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - `PBI-010` ✅ Complete
 - `PBI-011` ✅ Complete
 - `PBI-012` ✅ Complete
-- `PBI-013` ✅ Complete — character sheet styles and styled nav link (branch `increment/character-sheet-improvements`, merged into increment)
+- `PBI-013` ✅ Complete — character sheet styles and styled nav link
 - `PBI-014` ✅ Complete — trait score input width widened to prevent clipping
 - `PBI-015` ✅ Complete — slot trackers fill/empty as sequential gauges via `gaugeToggle`
 - `PBI-016` ✅ Complete — Class Feature section moved below two-column grid for full width
+- `PBI-017` ✅ Complete — backend parses `STARTING HIT POINTS` at ingestion into `hpSlotCount`; frontend wires `hpSolidCount` through context into `DamageHealthSection`
+- `PBI-018` ✅ Complete — `extractDomains` fixed to capture `<a>` link text instead of stopping at first HTML tag
+- `PBI-019` ✅ Complete — experience lines split into separate name (text) and modifier (number) fields; `ExperienceEntry` type, reducer, hook, component, and CSS updated
 
 **Feature files:** `dev-flow/product/`
 - `PBI-001-security-baseline.feature` ✅
@@ -104,6 +107,9 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - `PBI-014-trait-input-width.feature` ✅
 - `PBI-015-slot-tracker-gauge-behaviour.feature` ✅
 - `PBI-016-class-feature-full-width.feature` ✅
+- `PBI-017-class-hp-slot-count.feature` ✅
+- `PBI-018-domain-badges-fix.feature` ✅
+- `PBI-019-experience-name-and-modifier.feature` ✅
 
 **Priority order:** — awaiting increment validation
 
@@ -120,6 +126,9 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - XSS e2e scenario (PBI-009 `@security @frontend`): real Playwright `page.on('dialog', ...)` assertion in place — TD-003 resolved.
 - Slot gauges: `gaugeToggle(slots, index)` in `CharacterContext.tsx` handles fill-right/empty-right for HP, stress, hope, armor, and proficiency. Clicking slot N fills 0..N; clicking the last-filled slot empties it.
 - AppPage.ts `clickSlot(testId)` takes a full test ID string; `areSlotsMarkedInRange(prefix, from, to)` builds IDs as `${prefix}-${i}`. Armor slots are 0-indexed in the DOM (`armor-slot-0` = slot 1); use `clickArmorSlot(n)` / `isArmorSlotMarked(n)` which handle the offset.
+- Experience lines (PBI-019): each row has `data-testid="experience-line-{N}-name"` and `data-testid="experience-line-{N}-modifier"`. `AppPage.getExperienceLineCount()` counts `.experience-section__row` elements; `fillExperienceLine` / `getExperienceLineValue` target the `-name` input.
+- HP solid/dashed split (PBI-017): `hpSolidCount` lives in `CharacterState` (default 6); set via `SET_IDENTITY` when class changes in `ClassHeader`. `useCharacterHealth` exposes it; `DamageHealthSection` uses it directly.
+- Domain badges (PBI-018): `extractDomains` in `classContentParsers.ts` parses `<a>` tags from the HTML section between `DOMAINS:</strong>` and `<br`. Domain names come from link text, not plain text nodes.
 - Version control: all work happens on `increment/<slug>` or `fix/PBI-XXX-<slug>` branches in the main working tree. No git worktrees (removed from guidelines 2026-05-14).
 
 **Technical debt:** `dev-flow/product/technical-debt-backlog.md`
@@ -142,8 +151,9 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - `ADR-011-react-router-url-navigation.md` — BrowserRouter in index.tsx; /:type/:filename route; DetailRoute uses fetchItemBySlug (GET /api/srd/{slug}) not search
 - `ADR-012-character-sheet-state-management.md` — React Context + useReducer scoped to character-sheet feature; approved 2026-05-14
 - `ADR-013-weapon-armor-srd-item-types.md` — WEAPONS/ARMOR as structured SrdItem types in srd.json; HTML-parsing amendment approved 2026-05-14
+- `ADR-014-class-hp-slot-count.md` — `hpSlotCount` parsed from CLASSES content at ingestion, stored as nullable `Integer` on `SrdItem`; approved 2026-05-14
 
-**Last updated:** 2026-05-14 — PBI-013–016 implemented and tested; tsc 0 errors; all @frontend step definitions in place; increment on `increment/character-sheet-improvements`, PR pending merge
+**Last updated:** 2026-05-14 — PBI-017–019 implemented and tested; all @frontend and @backend step definitions in place; increment on `increment/character-sheet-hp-domains-experience`, PR pending merge
 
 ---
 

--- a/backend/src/main/java/com/dhsrd/domain/SrdService.java
+++ b/backend/src/main/java/com/dhsrd/domain/SrdService.java
@@ -16,13 +16,19 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Service
 public class SrdService {
 
+    private static final Logger log = Logger.getLogger(SrdService.class.getName());
     private static final int MAX_BULK_ITEMS = 2000;
     private static final int DEFAULT_FROM = 0;
     private static final int DEFAULT_SIZE = 300;
+    private static final Pattern HP_SLOT_PATTERN =
+            Pattern.compile("STARTING HIT POINTS[^>]*>\\s*(\\d+)", Pattern.CASE_INSENSITIVE);
 
     private final SrdItemRepository repository;
     private final LuceneService luceneService;
@@ -66,6 +72,7 @@ public class SrdService {
             try (InputStream is = getClass().getResourceAsStream("/srd.json")) {
                 if (is == null) return;
                 List<SrdItem> items = objectMapper.readValue(is, new TypeReference<>() {});
+                items.forEach(this::enrichClassItem);
                 List<SrdItem> saved = repository.saveAll(items);
                 luceneService.indexAll(saved);
             }
@@ -109,5 +116,17 @@ public class SrdService {
             item.setContent(Jsoup.clean(item.getContent(), Safelist.basic()));
         }
         return item;
+    }
+
+    private void enrichClassItem(SrdItem item) {
+        if (item.getType() != SrdType.CLASSES || item.getContent() == null) {
+            return;
+        }
+        Matcher matcher = HP_SLOT_PATTERN.matcher(item.getContent());
+        if (matcher.find()) {
+            item.setHpSlotCount(Integer.parseInt(matcher.group(1)));
+        } else {
+            log.warning("No STARTING HIT POINTS found in CLASSES item: " + item.getSlug());
+        }
     }
 }

--- a/backend/src/main/java/com/dhsrd/model/SrdItem.java
+++ b/backend/src/main/java/com/dhsrd/model/SrdItem.java
@@ -1,9 +1,11 @@
 package com.dhsrd.model;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.persistence.*;
 import java.time.Instant;
 import java.util.Set;
 
+@JsonInclude(JsonInclude.Include.NON_NULL)
 @Entity
 @Table(name = "srd_items", indexes = {
         @Index(name="idx_srd_slug", columnList = "slug", unique = true),
@@ -34,7 +36,8 @@ public class SrdItem {
     private String subtype;
 
     private Integer recallCost;
-    private Integer level;   // optional
+    private Integer level;
+    private Integer hpSlotCount;
     private String sourceRef;
 
     @ElementCollection(fetch = FetchType.EAGER)
@@ -74,6 +77,9 @@ public class SrdItem {
 
     public Integer getRecallCost() { return recallCost; }
     public void setRecallCost(Integer recallCost) { this.recallCost = recallCost; }
+
+    public Integer getHpSlotCount() { return hpSlotCount; }
+    public void setHpSlotCount(Integer hpSlotCount) { this.hpSlotCount = hpSlotCount; }
 
     public String getSourceRef() { return sourceRef; }
     public void setSourceRef(String sourceRef) { this.sourceRef = sourceRef; }

--- a/backend/src/test/java/com/dhsrd/cucumber/steps/HpSlotCountStepDefs.java
+++ b/backend/src/test/java/com/dhsrd/cucumber/steps/HpSlotCountStepDefs.java
@@ -1,0 +1,61 @@
+package com.dhsrd.cucumber.steps;
+
+import com.dhsrd.model.SrdType;
+import com.dhsrd.repo.SrdItemRepository;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class HpSlotCountStepDefs {
+
+    private final TestRestTemplate restTemplate;
+    private final SrdItemRepository repository;
+    private ResponseEntity<Map> response;
+    private List<ResponseEntity<Map>> allClassResponses;
+
+    public HpSlotCountStepDefs(TestRestTemplate restTemplate, SrdItemRepository repository) {
+        this.restTemplate = restTemplate;
+        this.repository = repository;
+    }
+
+    @When("a request is made for the class with slug {string}")
+    public void should_request_class_by_slug(String slug) {
+        response = restTemplate.getForEntity("/api/srd/" + slug, Map.class);
+    }
+
+    @Then("the response includes a field {string} with value {int}")
+    public void should_have_field_with_value(String field, int expectedValue) {
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        Map<?, ?> body = response.getBody();
+        assertThat(body).isNotNull();
+        assertThat(body).containsKey(field);
+        assertThat(((Number) body.get(field)).intValue()).isEqualTo(expectedValue);
+    }
+
+    @When("a request is made for each class in the system")
+    @SuppressWarnings("unchecked")
+    public void should_request_all_classes() {
+        allClassResponses = repository.findAll().stream()
+                .filter(item -> item.getType() == SrdType.CLASSES)
+                .map(item -> restTemplate.getForEntity("/api/srd/" + item.getSlug(), Map.class))
+                .toList();
+        assertThat(allClassResponses).isNotEmpty();
+    }
+
+    @Then("every response includes a field {string} with a value greater than 0")
+    public void should_all_have_field_greater_than_zero(String field) {
+        for (ResponseEntity<Map> r : allClassResponses) {
+            assertThat(r.getStatusCode().is2xxSuccessful()).isTrue();
+            Map<?, ?> body = r.getBody();
+            assertThat(body).isNotNull();
+            assertThat(body).containsKey(field);
+            assertThat(((Number) body.get(field)).intValue()).isGreaterThan(0);
+        }
+    }
+}

--- a/backend/src/test/java/com/dhsrd/domain/SrdServiceTest.java
+++ b/backend/src/test/java/com/dhsrd/domain/SrdServiceTest.java
@@ -246,6 +246,50 @@ class SrdServiceTest {
         verify(luceneService).indexAll(anyList());
     }
 
+    // --- loadInitialData / enrichClassItem (PBI-017) ---
+
+    @Test
+    void should_setHpSlotCount_when_classContentContainsStartingHitPoints() throws Exception {
+        when(luceneService.isEmpty()).thenReturn(true);
+        when(repository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        srdService.loadInitialData();
+
+        ArgumentCaptor<List<SrdItem>> captor = ArgumentCaptor.forClass(List.class);
+        verify(repository).saveAll(captor.capture());
+        List<SrdItem> saved = captor.getValue();
+        List<SrdItem> classes = saved.stream()
+                .filter(i -> i.getType() == SrdType.CLASSES)
+                .toList();
+        assertThat(classes).isNotEmpty();
+        for (SrdItem cls : classes) {
+            assertThat(cls.getHpSlotCount())
+                    .as("hpSlotCount must be set for class '%s'", cls.getSlug())
+                    .isNotNull()
+                    .isGreaterThan(0);
+        }
+    }
+
+    @Test
+    void should_notSetHpSlotCount_when_itemTypeIsNotClasses() throws Exception {
+        when(luceneService.isEmpty()).thenReturn(true);
+        when(repository.saveAll(anyList())).thenAnswer(inv -> inv.getArgument(0));
+
+        srdService.loadInitialData();
+
+        ArgumentCaptor<List<SrdItem>> captor = ArgumentCaptor.forClass(List.class);
+        verify(repository).saveAll(captor.capture());
+        List<SrdItem> nonClasses = captor.getValue().stream()
+                .filter(i -> i.getType() != SrdType.CLASSES)
+                .toList();
+        assertThat(nonClasses).isNotEmpty();
+        for (SrdItem item : nonClasses) {
+            assertThat(item.getHpSlotCount())
+                    .as("hpSlotCount should remain null for non-class item '%s'", item.getSlug())
+                    .isNull();
+        }
+    }
+
     // --- helpers ---
 
     private SrdItem itemWithContent(String content) {

--- a/backend/src/test/resources/features/PBI-017-class-hp-slot-count.feature
+++ b/backend/src/test/resources/features/PBI-017-class-hp-slot-count.feature
@@ -1,0 +1,23 @@
+Feature: Class API response includes starting HP slot count
+  As a frontend client,
+  I want the class SRD item response to include the hpSlotCount field,
+  So that the character sheet can render the correct number of solid HP boxes.
+  Backlog item: PBI-017
+
+  Background:
+    Given the SRD data has been loaded
+
+  @regression @backend
+  Scenario: Class API response includes the starting HP slot count for Bard
+    When a request is made for the class with slug "bard"
+    Then the response includes a field "hpSlotCount" with value 5
+
+  @regression @backend
+  Scenario: Class API response includes the starting HP slot count for Guardian
+    When a request is made for the class with slug "guardian"
+    Then the response includes a field "hpSlotCount" with value 7
+
+  @regression @backend
+  Scenario: All class API responses include a non-zero hpSlotCount
+    When a request is made for each class in the system
+    Then every response includes a field "hpSlotCount" with a value greater than 0

--- a/dev-flow/design/PBI-017-class-hp-slot-count-design.md
+++ b/dev-flow/design/PBI-017-class-hp-slot-count-design.md
@@ -1,0 +1,121 @@
+# Design Specification — PBI-017: Class-specific HP slot count
+
+**PBI:** PBI-017
+**Design Agent output date:** 2026-05-14
+**Status:** Draft
+
+---
+
+## 1. Feature Summary
+
+When a class is selected on the character sheet, the number of solid-bordered HP boxes in the Damage & Health section updates to reflect that class's starting hit point count. The remaining boxes stay dashed. Previously this split was hardcoded; it now responds to the selected class.
+
+---
+
+## 2. Scope
+
+**IN scope for this design:**
+- The solid/dashed split of the 10 HP boxes in `DamageHealthSection` reacts to the selected class.
+- When no class is selected the split falls back to 6 solid / 4 dashed (current behaviour, unchanged).
+
+**OUT of scope:**
+- Visual styling of the HP boxes — no changes to colours, borders, sizes, or marked state.
+- Stress slot count (not class-dependent in these rules; remains hardcoded at 4).
+- HP slots gained from levelling up (Tier advancement mechanics).
+- Any change to the total number of HP slots (always 10).
+
+---
+
+## 3. Pages and Routes Affected
+
+| Route | Page/Component | New or Modified |
+|---|---|---|
+| `/character-sheet` | `DamageHealthSection` | Modified — reads `hpSlotCount` from context instead of constant |
+
+---
+
+## 4. Component Inventory
+
+| Component | Status | Location | Responsibility |
+|---|---|---|---|
+| `DamageHealthSection` | Modified | `src/features/character-sheet/components/DamageHealthSection.tsx` | Replaces hardcoded `HP_SOLID_COUNT = 6` with the class's `hpSlotCount` value read from context |
+| `CharacterContext` / reducer | Modified | `src/features/character-sheet/context/CharacterContext.tsx` | Exposes `hpSolidCount` derived from the selected class's SRD data |
+| `useCharacterHealth` | Modified | `src/features/character-sheet/hooks/useCharacterHealth.ts` | Surfaces `hpSolidCount` to the component |
+| `ClassHeader` (or class-selection handler) | Modified | `src/features/character-sheet/components/ClassHeader.tsx` | On class selection, stores or derives `hpSlotCount` into context state |
+
+No new components are required.
+
+---
+
+## 5. Layout and Visual Structure
+
+No layout changes. The HP tracker row already renders 10 clickable slots. The only change is which slots are styled `--solid` vs `--dashed`. The visual appearance of each slot type is unchanged.
+
+```
+HP  [■][■][■][■][■][■][□][□][□][□]   ← Bard: 5 solid (■), 5 dashed (□) — was 6/4
+HP  [■][■][■][■][■][■][■][□][□][□]   ← Guardian: 7 solid, 3 dashed — was 6/4
+```
+
+The transition from one split to another happens immediately on class selection, with no animation.
+
+---
+
+## 6. Interaction Specification
+
+### Class selection changes HP solid count
+
+**Trigger:** User selects a class from the class dropdown in `ClassHeader`.
+**Precondition:** The HP tracker is visible.
+**Outcome:** The solid/dashed split of the 10 HP boxes updates immediately to reflect the selected class's `hpSlotCount`.
+
+**States to design for:**
+
+| State | Visual treatment |
+|---|---|
+| No class selected | 6 solid / 4 dashed (default fallback — no change from current) |
+| Class selected | `hpSlotCount` solid / `(10 - hpSlotCount)` dashed |
+| Class changed to another class | Split updates immediately; marked (filled) slots are not cleared |
+| Class data loading | Retain previous solid count until new class data resolves — no flicker |
+
+**Note on marked slots and split changes:** If a player has, say, 8 HP slots marked and then switches from Guardian (7 solid) to Bard (5 solid), slots 6–8 remain marked — they just change from solid to dashed. The marking state is independent of the solid/dashed styling. This is correct game behaviour (the player's HP doesn't reset on class change).
+
+---
+
+## 7. Copy and Labels
+
+No copy changes. All existing aria-labels, test IDs, and data attributes are unchanged in format. The `data-slot-type` attribute (`"solid"` or `"dashed"`) continues to reflect the actual slot type after the split updates.
+
+---
+
+## 8. Accessibility Notes
+
+- No focus management changes required.
+- `aria-label` for each HP slot already includes the slot number and marked state — no changes needed.
+- `data-slot-type` attribute is preserved; test selectors and screen-reader behaviour are unaffected.
+
+---
+
+## 9. Design Decisions and Rationale
+
+| Decision | Alternatives considered | Rationale |
+|---|---|---|
+| Derive `hpSolidCount` from the already-fetched class SrdItem rather than a separate API call | New endpoint `/api/srd/classes/{slug}/stats` | The class item is already in memory when a class is selected. A separate endpoint adds a network round-trip for data already available. |
+| Fall back to 6 solid slots when no class is selected | Fall back to 5 (the most common value) or 0 | 6 matches the current visible default and avoids a visible change for users who haven't selected a class yet. |
+| Do not reset marked HP slots when the class changes | Clear all marks on class change | Players may be mid-session when adjusting their class field. Clearing HP marks would be destructive and surprising. |
+
+---
+
+## 10. Open Design Questions
+
+No open design questions.
+
+---
+
+## 11. Scenario Traceability
+
+| Scenario | Addressed by |
+|---|---|
+| HP boxes reflect the selected class's starting hit point count | Section 6 — Class selection changes HP solid count |
+| HP box borders update when a different class is selected | Section 6 — Class selection; Section 5 — immediate update behaviour |
+| HP boxes show a default when no class is selected | Section 6 — No class selected state |
+| Each class renders the correct number of solid HP boxes | Section 5 — Visual structure; values driven by backend data |

--- a/dev-flow/design/PBI-019-experience-name-and-modifier-design.md
+++ b/dev-flow/design/PBI-019-experience-name-and-modifier-design.md
@@ -1,0 +1,157 @@
+# Design Specification — PBI-019: Experience name and modifier fields
+
+**PBI:** PBI-019
+**Design Agent output date:** 2026-05-14
+**Status:** Draft
+
+---
+
+## 1. Feature Summary
+
+Each of the 5 experience rows on the character sheet gains a second input field for the modifier (e.g. 2 or −1). Players can record a structured entry like "Charlatan" / 2 in the same row, matching how experiences are referenced during play.
+
+---
+
+## 2. Scope
+
+**IN scope for this design:**
+- Each experience row split into two fields: name (free text, wider) and modifier (numeric, narrow, styled like trait score inputs).
+- State model updated from `string[]` to `Array<{name: string; modifier: number | null}>`.
+
+**OUT of scope:**
+- Validation or formatting enforcement beyond numeric type.
+- Auto-calculation or aggregation of modifiers.
+- Any change to the number of experience rows (still 5).
+- Changes to any other section of the character sheet.
+
+---
+
+## 3. Pages and Routes Affected
+
+| Route | Page/Component | New or Modified |
+|---|---|---|
+| `/character-sheet` | `ExperienceSection` | Modified — each row gains a numeric modifier input |
+
+---
+
+## 4. Component Inventory
+
+| Component | Status | Location | Responsibility |
+|---|---|---|---|
+| `ExperienceSection` | Modified | `src/features/character-sheet/components/ExperienceSection.tsx` | Renders two inputs per row instead of one |
+| `CharacterContext` / reducer | Modified | `src/features/character-sheet/context/CharacterContext.tsx` | State shape changes to `Array<{name: string; modifier: number | null}>` |
+| `useCharacterHope` | Modified | `src/features/character-sheet/hooks/useCharacterHope.ts` | `setExperienceName(index, value)` and `setExperienceModifier(index, value)` replace the single `setExperience` |
+| `character.ts` types | Modified | `src/features/character-sheet/types/character.ts` | `experience` field updated to new shape |
+
+No new components are required.
+
+---
+
+## 5. Layout and Visual Structure
+
+### Experience row — current
+
+```
+┌─────────────────────────────────────────┐
+│  [Name / description text input       ] │
+└─────────────────────────────────────────┘
+```
+
+### Experience row — new
+
+```
+┌──────────────────────────────────┬──────┐
+│  [Name / description text input] │ [ 2] │
+└──────────────────────────────────┴──────┘
+```
+
+The two inputs sit in a single row using flexbox (`flex-direction: row`). The name field takes the majority of the available width; the modifier field is a fixed narrow width matching the `traits-section__score-input` width (the trait score inputs established in PBI-010).
+
+The 5 rows stack vertically as before.
+
+**Sizing and spacing notes:**
+- Name field: `flex: 1` (takes remaining space after modifier).
+- Modifier field: same fixed width as `traits-section__score-input` — reuses that CSS class directly, or a dedicated `experience-section__modifier-input` class that matches its dimensions.
+- Gap between name and modifier: uses the same `gap` value as other inline field pairs on the sheet.
+- Row wrapper: `display: flex; align-items: center`.
+
+**Responsive behaviour:**
+- No responsive breakpoints required; the character sheet has a fixed-width layout.
+
+---
+
+## 6. Interaction Specification
+
+### Entering an experience name
+
+**Trigger:** User types in the name field of any experience row.
+**Precondition:** Character sheet is open.
+**Outcome:** Name field updates; modifier field in the same row is unaffected.
+
+### Entering an experience modifier
+
+**Trigger:** User types an integer (positive or negative) in the modifier field.
+**Precondition:** Character sheet is open.
+**Outcome:** Modifier field updates to the entered number. Non-numeric input is ignored (native `type="number"` behaviour). Name field in the same row is unaffected.
+
+**States to design for:**
+
+| State | Visual treatment |
+|---|---|
+| Empty (initial) | Both fields show empty — consistent with how trait score inputs appear when blank |
+| Name entered, modifier empty | Name field shows text; modifier field is blank |
+| Both filled | Both fields show their respective values |
+
+No loading, error, or success states — both fields are local form inputs.
+
+---
+
+## 7. Copy and Labels
+
+| Element | Copy | Notes |
+|---|---|---|
+| Name field placeholder | (none) | Consistent with other text inputs on the sheet |
+| Modifier field placeholder | (none) | Consistent with trait score inputs which have no placeholder |
+| Name field aria-label | `"Experience line {N} name"` | e.g. "Experience line 1 name" |
+| Modifier field aria-label | `"Experience line {N} modifier"` | e.g. "Experience line 1 modifier" |
+| Name field data-testid | `"experience-line-{N}-name"` | e.g. "experience-line-1-name" |
+| Modifier field data-testid | `"experience-line-{N}-modifier"` | e.g. "experience-line-1-modifier" |
+
+---
+
+## 8. Accessibility Notes
+
+- Both fields in each row are separately labelled with aria-labels that distinguish name from modifier.
+- Tab order follows reading order: name field row 1 → modifier field row 1 → name field row 2 → modifier field row 2 → etc.
+- `type="number"` provides native browser spin controls; these are acceptable for a numeric modifier field.
+- No focus management changes required on interaction.
+
+---
+
+## 9. Design Decisions and Rationale
+
+| Decision | Alternatives considered | Rationale |
+|---|---|---|
+| Modifier field is `type="number"` styled like trait score inputs | `type="text"` to allow formats like "+1d6" | User confirmed modifiers are always numeric (positive or negative integers). Using `type="number"` with the established trait input style maintains visual consistency and correctly constrains the field to its intended values. |
+| Modifier state is `number | null` (not `string`) | `string` with parseInt on use | Matches the existing pattern for numeric character fields (`traits`, `damageThresholds`). `null` represents an empty/unset field, consistent with `traits[key] ?? ''` rendering pattern. |
+| No placeholder text on either field | Placeholder like "Name" / "0" | The existing experience inputs have no placeholder, and trait score inputs have no placeholder. Adding one would be inconsistent. |
+| Fixed narrow width matching trait score input | Auto-width or percentage | Reuses the established dimension, keeps the column visually aligned across all 5 rows, and constrains the field to its intended use. |
+| Single flex row per entry, no label above | Label row above inputs | The sheet uses inline patterns for multi-field rows (weapon name/range). No other section adds a label row above inputs. |
+
+---
+
+## 10. Open Design Questions
+
+No open design questions.
+
+---
+
+## 11. Scenario Traceability
+
+| Scenario | Addressed by |
+|---|---|
+| Each experience line shows a name field and a modifier field | Section 5 — Layout; Section 4 — Component inventory |
+| Player can enter an experience name and modifier | Section 6 — Entering name / modifier interactions |
+| Name and modifier fields are independent across experience lines | Section 6 — both interactions; state is per-row |
+| Modifier field accepts non-numeric formats | N/A — superseded by user confirmation that modifier is always numeric; `type="number"` is correct |
+| Experience fields are empty on initial load | Section 6 — Empty state |

--- a/dev-flow/engineering/architecture/ADR-014-class-hp-slot-count.md
+++ b/dev-flow/engineering/architecture/ADR-014-class-hp-slot-count.md
@@ -1,0 +1,235 @@
+# ADR-014: Surfacing per-class HP slot count from the backend
+
+> **Status:** `Proposed`
+> **Date:** 2026-05-14
+> **Backlog item:** PBI-017
+> **Decider:** Architecture Agent → 👤 Human approval required
+
+---
+
+## Context
+
+PBI-017 requires the character sheet to render the correct number of solid-bordered HP boxes for the selected class. Currently `DamageHealthSection.tsx` uses a hardcoded constant (`HP_SOLID_COUNT = 6`). The actual per-class starting HP values differ across the nine classes (range: 5–7) and are the authoritative source for how many solid vs dashed HP boxes a player's sheet should show.
+
+The per-class HP count is already embedded in the HTML content of each CLASSES `SrdItem` in `srd.json` — specifically the line `STARTING HIT POINTS: N` inside each class's content block. The frontend must not parse this itself (the product requirement states business logic of this kind belongs in the backend).
+
+A decision is needed for how the backend surfaces this numeric value to the frontend, given that `SrdItem` currently has no dedicated field for it.
+
+---
+
+## Decision Drivers
+
+- **Primary:** Business logic (extracting game stats from SRD content) must not live in the frontend
+- **Primary:** Consistency with existing SrdItem data access pattern — the frontend already has the selected class's `SrdItem` in memory; no additional API call should be needed
+- **Primary:** The value must be type-safe and unambiguous in the API response
+- **Secondary:** Minimal schema disruption; the existing optional numeric fields (`level`, `recallCost`) provide an established pattern
+- **Constraints:** `SrdItem` is a shared entity used by all SRD types; any new field must be nullable so it doesn't break non-CLASSES items
+
+---
+
+## Options Considered
+
+### Option A: Parse content at request time in the service layer; return as an enriched field
+
+When the frontend requests CLASSES items via `POST /api/search`, the `SrdService` parses `STARTING HIT POINTS: N` from the content string before returning results. The parsed value is projected onto the existing `hpSlotCount` field (or returned via a DTO wrapper). The raw entity is not changed.
+
+**Pros:**
+- No database schema change
+- No ingestion code change
+- Data remains in one canonical location (the content HTML)
+
+**Cons:**
+- Parsing runs on every API request rather than once at ingest time — minor but unnecessary runtime overhead
+- The value is not independently testable at persistence level; a malformed content string would silently return null/0 to the frontend
+- Requires either a DTO wrapper (new pattern) or shoe-horning the value into an existing field (misleading semantics)
+
+**Security implications:**
+- The content field is already sanitised at ingest (ADR-002); no new trust boundary
+
+---
+
+### Option B: Parse content at ingestion time; store in a new `hpSlotCount` nullable field on `SrdItem`
+
+Add `Integer hpSlotCount` to the `SrdItem` JPA entity. During data loading (`DataLoader` / ingestion service), parse `STARTING HIT POINTS: N` from the content of each CLASSES item and store it in the field. All other item types leave the field null.
+
+The existing `POST /api/search` response already serialises all `SrdItem` fields, so `hpSlotCount` is included automatically in the response for CLASSES items. No new endpoint or response shape is needed.
+
+The frontend `SrdItem` TypeScript type gains an optional `hpSlotCount?: number` field. The frontend reads it from the already-fetched class object — no additional API call.
+
+**Pros:**
+- Parsing happens once at startup, not on every request
+- The value is stored, independently queryable, and testable at the repository level
+- Consistent with the existing optional numeric field pattern (`level`, `recallCost`, `subtype`)
+- No new endpoint or DTO — `hpSlotCount` surfaces naturally through the existing `POST /api/search` response
+- Frontend receives a clean typed field, not a tag string to parse
+
+**Cons:**
+- Adds one nullable column to the `SrdItem` table — only populated for CLASSES rows
+- H2 schema auto-updates on startup (no manual migration needed for development); a production deployment would need a schema migration script
+
+**Security implications:**
+- No new endpoint or trust boundary
+- The content regex is applied to backend-owned, already-sanitised data; no user input involved
+
+---
+
+### Option C: Add `hp-slots:N` tags to CLASSES entries in srd.json
+
+Manually edit each CLASSES entry in `srd.json` to add a tag like `"hp-slots:5"`. The frontend (or backend) extracts the numeric value from the tag string.
+
+**Pros:**
+- No schema change to the entity
+- No ingestion parsing code required
+
+**Cons:**
+- Duplicates data that already exists canonically in the content — two sources of truth for the same value
+- If the tag is parsed on the frontend it violates the "no business logic in frontend" requirement; if parsed in the backend it requires the same ingestion-time extraction as Option B but without the clean typed field
+- Tag strings are weakly typed; `"hp-slots:five"` would not be caught at compile time
+
+**Security implications:**
+- No concerns
+
+---
+
+## Decision
+
+**We will use Option B: parse content at ingestion time and store in a new `hpSlotCount` nullable field on `SrdItem`.**
+
+Option A's runtime parsing adds unnecessary overhead and is harder to test in isolation. Option C duplicates data and is weakly typed. Option B is consistent with the existing nullable numeric field pattern on `SrdItem`, surfaces the value through the already-established search API response with zero new endpoint surface, and keeps parsing in the backend exactly once — at startup when the `srd.json` data is loaded.
+
+The one-column schema change is low risk: H2 auto-updates on startup; the field is nullable so all existing non-CLASSES items are unaffected; the API response for CLASSES gains a new optional field, which is a backward-compatible additive change.
+
+---
+
+## Architecture / Flow Diagram
+
+```mermaid
+flowchart LR
+    subgraph Backend startup
+        JSON["srd.json\nCLASSES entries with\n'STARTING HIT POINTS: N'"]
+        Loader["DataLoader\n(ingestion)"]
+        Parser["HpSlotCountParser\n(extracts N from content)"]
+        DB["H2 DB\nSrdItem.hpSlotCount = N"]
+        Lucene["Lucene index"]
+
+        JSON --> Loader --> Parser --> DB
+        DB --> Lucene
+    end
+
+    subgraph Runtime
+        FE_Load["useSrdClasses()\nfetches CLASSES on mount"]
+        API["POST /api/search\n{ types: ['CLASSES'] }"]
+        Ctrl["SrdController"]
+        Svc["SrdService"]
+        FE_Load --> API --> Ctrl --> Svc --> DB
+
+        FE_State["CharacterContext\nstores hpSolidCount\nwhen class changes"]
+        FE_Comp["DamageHealthSection\nreads hpSolidCount\nfrom context"]
+
+        DB -->|SrdItem incl. hpSlotCount| Svc
+        Svc -->|JSON response| FE_Load
+        FE_Load -->|selectedClass.hpSlotCount| FE_State
+        FE_State -->|hpSolidCount| FE_Comp
+    end
+```
+
+### Backend changes
+
+**`SrdItem.java`** — new nullable field:
+```java
+@Column(name = "hp_slot_count")
+private Integer hpSlotCount;
+```
+
+**Ingestion service** — parse during data load:
+```
+Pattern: STARTING HIT POINTS:\s*(\d+)
+Applied to: content of each CLASSES item
+Stored in: SrdItem.hpSlotCount
+Items where content does not match: hpSlotCount remains null
+```
+
+### API response change (additive, backward-compatible)
+
+`POST /api/search` response for a CLASSES item gains one new field:
+```json
+{
+  "type": "CLASSES",
+  "slug": "bard",
+  "title": "Bard",
+  "hpSlotCount": 5,
+  ...existing fields unchanged...
+}
+```
+
+Non-CLASSES items: `hpSlotCount` is absent (null is omitted from JSON serialisation via `@JsonInclude(NON_NULL)`).
+
+### Frontend changes
+
+**`SrdItem` TypeScript type** (`src/types/index.ts`):
+```typescript
+hpSlotCount?: number;
+```
+
+**`CharacterContext` / reducer** — when class changes, store `hpSlotCount`:
+```
+SET_IDENTITY action: if payload includes classSlug, also set hpSolidCount
+  = selectedClass.hpSlotCount ?? 6  (fallback to 6 if null)
+```
+
+**`DamageHealthSection`** — replaces `HP_SOLID_COUNT = 6` constant with `hpSolidCount` from `useCharacterHealth()`.
+
+---
+
+## Consequences
+
+### What becomes easier
+- Per-class HP slot count is correctly driven by backend data for all 9 classes
+- Future SRD updates (new classes, HP changes) only require a `srd.json` update and re-ingestion
+- `hpSlotCount` is independently testable at the backend acceptance test level
+
+### What becomes harder or riskier
+- Production deployments need a one-column `ALTER TABLE` migration (low risk — nullable column with no default constraint)
+- A regex parse failure during ingestion (malformed content) silently results in `null`; the frontend fallback of 6 would hide the problem. The ingestion service should log a warning for any CLASSES item where parsing returns null.
+
+### Impact on existing system
+- **API contracts:** Additive only — existing consumers receive one new nullable field on CLASSES items. No existing fields change.
+- **Database migration:** One new nullable column `hp_slot_count` on `srd_item` table. H2 auto-updates in dev. Production requires `ALTER TABLE srd_item ADD COLUMN hp_slot_count INTEGER;`
+- **Auth/authorisation behaviour:** No change
+- **New external dependencies:** No
+
+---
+
+## Security Considerations
+
+- **Authentication:** No change — `POST /api/search` is a public read endpoint
+- **Authorisation:** No change
+- **Data sensitivity:** `hpSlotCount` is public SRD game data; no sensitive data involved
+- **Attack surface:** No new endpoints introduced
+- **Threat mitigations:** The regex is applied only to backend-owned, Jsoup-sanitised content (ADR-002). No user input reaches the parser.
+
+---
+
+## Acceptance Scenarios Affected
+
+- `PBI-017-class-hp-slot-count.feature` — all scenarios
+
+---
+
+## 👤 Human Review Checklist
+
+- [ ] The problem description matches my understanding of the intent
+- [ ] At least two options were genuinely considered (not a rubber stamp)
+- [ ] The chosen option's trade-offs are acceptable
+- [ ] The flow diagram / sequence makes sense end-to-end
+- [ ] The security section addresses auth, authorisation, and data sensitivity
+- [ ] No existing API contracts are broken without explicit acknowledgment
+- [ ] I am comfortable with this decision proceeding to implementation
+
+**Decision:** `Approved` / `Rejected — [reason]` / `Needs revision — [what to revisit]`
+
+---
+
+## Notes
+
+- Related ADRs: [ADR-010](./ADR-010-api-service-layer-and-hooks.md) (service + hook pattern), [ADR-012](./ADR-012-character-sheet-state-management.md) (React Context + useReducer for character state), [ADR-013](./ADR-013-weapon-armor-srd-item-types.md) (precedent for content-parsing at ingestion vs frontend)

--- a/dev-flow/engineering/architecture/PBI-017-class-hp-slot-count-flow.md
+++ b/dev-flow/engineering/architecture/PBI-017-class-hp-slot-count-flow.md
@@ -1,0 +1,86 @@
+# Flow Descriptor — PBI-017: Class-specific HP slot count
+
+**PBI:** PBI-017
+**ADR:** ADR-014 (required — see that document for the full option analysis)
+**Date:** 2026-05-14
+
+---
+
+## 1. What this builds
+
+When a player selects a class on the character sheet, the solid/dashed split of the 10 HP boxes in the Damage & Health section updates to reflect that class's starting HP count (e.g. Bard = 5 solid, Guardian = 7 solid). The per-class count is parsed from the SRD content at backend startup and returned as `hpSlotCount` on each CLASSES item. The frontend replaces the hardcoded `HP_SOLID_COUNT = 6` constant with the value from the selected class.
+
+---
+
+## 2. Component map
+
+| Component | Layer | Status | Change |
+|---|---|---|---|
+| `SrdItem.java` | Backend — model | Modified | Add `Integer hpSlotCount` nullable field |
+| `DataLoader` / ingestion service | Backend — infrastructure | Modified | Parse `STARTING HIT POINTS: N` from CLASSES content; store in `hpSlotCount` |
+| `SrdController` | Backend — API | Unchanged | Already serialises all `SrdItem` fields |
+| `SrdItem` TypeScript type (`src/types/index.ts`) | Frontend — types | Modified | Add `hpSlotCount?: number` |
+| `CharacterContext` / reducer | Frontend — state | Modified | Store `hpSolidCount` when class changes; fallback to 6 when null |
+| `useCharacterHealth` | Frontend — hook | Modified | Expose `hpSolidCount` from context |
+| `DamageHealthSection` | Frontend — component | Modified | Replace `HP_SOLID_COUNT` constant with `hpSolidCount` from hook |
+
+---
+
+## 3. Data flow
+
+```mermaid
+sequenceDiagram
+    participant JSON as srd.json
+    participant Loader as DataLoader
+    participant DB as H2 (SrdItem)
+    participant API as POST /api/search
+    participant Hook as useSrdClasses
+    participant Ctx as CharacterContext
+    participant Comp as DamageHealthSection
+
+    Note over JSON,DB: At startup
+    JSON->>Loader: CLASSES item (content contains "STARTING HIT POINTS: 5")
+    Loader->>Loader: regex extract → hpSlotCount = 5
+    Loader->>DB: SrdItem { slug: "bard", hpSlotCount: 5, ... }
+
+    Note over Hook,Comp: At runtime — user selects "Bard"
+    Hook->>API: POST /api/search { types: ["CLASSES"] }
+    API->>Hook: [ { slug: "bard", hpSlotCount: 5, ... }, ... ]
+    Hook->>Ctx: user selects Bard → SET_IDENTITY { classSlug: "bard", hpSolidCount: 5 }
+    Ctx->>Comp: hpSolidCount = 5
+    Comp->>Comp: slots 0–4 → --solid; slots 5–9 → --dashed
+```
+
+---
+
+## 4. API contract
+
+**No new endpoint.** The existing `POST /api/search` response for CLASSES items gains one additive field:
+
+```
+POST /api/search
+Request: { "types": ["CLASSES"] }  (unchanged)
+
+Response item — new field only:
+{
+  "hpSlotCount": 5   // Integer, non-null for CLASSES; absent for all other types
+}
+```
+
+This is a backward-compatible additive change. `@JsonInclude(NON_NULL)` ensures the field is omitted for all non-CLASSES items.
+
+---
+
+## 5. Security notes
+
+- `POST /api/search` is a public, read-only endpoint. No change to authentication or authorisation.
+- `hpSlotCount` is derived from backend-owned, Jsoup-sanitised content (ADR-002). No user input reaches the parser.
+- No new trust boundaries introduced.
+
+---
+
+## 6. Consistency notes
+
+- Follows the established nullable numeric field pattern on `SrdItem` (`level`, `recallCost`). See ADR-013 for precedent on extracting structured values from SRD content at ingestion time.
+- Frontend state storage of `hpSolidCount` in `CharacterContext` follows ADR-012 (React Context + useReducer). The value is stored alongside `classSlug` in the identity portion of character state, derived from the selected class at the point of selection.
+- The ingestion service must log a `WARN` for any CLASSES item where content parsing returns null, to surface ingestion errors during development.

--- a/dev-flow/engineering/architecture/PBI-018-domain-badges-fix-flow.md
+++ b/dev-flow/engineering/architecture/PBI-018-domain-badges-fix-flow.md
@@ -1,0 +1,72 @@
+# Flow Descriptor — PBI-018: Fix domain badges after class selection
+
+**PBI:** PBI-018
+**ADR:** None required — see architecture exemption note below
+**Date:** 2026-05-14
+
+---
+
+## Architecture exemption
+
+This bug fix requires no architecture checkpoint. The fix:
+- Corrects existing behaviour in a single frontend utility function (`extractDomains` in `classContentParsers.ts`)
+- Introduces no new components, patterns, or data model changes
+- Does not change any API contract
+- Follows the established pattern already present in the codebase (string parsing utilities in `utils/`)
+
+Implementation proceeds directly after this note is acknowledged.
+
+---
+
+## 1. What this builds
+
+Fixes `extractDomains()` in `frontend/src/features/character-sheet/utils/classContentParsers.ts` so that domain badges render correctly in `ClassHeader` after a class is selected.
+
+**Root cause:** The function captures the raw HTML text after `</strong>` (e.g. `" Grace &amp; Codex"`), then splits on `"&"`. Since the HTML entity `&amp;` contains a literal `&`, the split produces `["Grace ", "amp; Codex"]` — the second domain becomes `"amp; Codex"` rather than `"Codex"`. The result is two malformed domain names, neither matching any valid badge value, so `domains.length > 0` may be true but the badge content is wrong. In practice the regex itself may also fail to match depending on the exact HTML structure of the content, causing the function to return `[]`.
+
+**Fix:** Split on `"&amp;"` (the HTML entity as it appears in the raw HTML string) rather than `"&"`, then trim each part. This correctly splits `"Grace &amp; Codex"` into `["Grace", "Codex"]`.
+
+---
+
+## 2. Component map
+
+| Component | Layer | Status | Change |
+|---|---|---|---|
+| `classContentParsers.ts` | Frontend — utils | Modified | Fix `extractDomains` split delimiter from `"&"` to `"&amp;"` |
+| `ClassHeader.tsx` | Frontend — component | Unchanged | Already correct — renders domains returned by `extractDomains` |
+
+---
+
+## 3. Data flow
+
+No change to data flow. `extractDomains` is a pure function called with the already-fetched class `content` string. The fix is entirely within that function.
+
+Before fix:
+```
+content: "... <strong>• DOMAINS:</strong> Grace &amp; Codex ..."
+extractDomains → split("&") → ["Grace ", "amp; Codex"] → wrong
+```
+
+After fix:
+```
+content: "... <strong>• DOMAINS:</strong> Grace &amp; Codex ..."
+extractDomains → split("&amp;") → ["Grace", "Codex"] → correct
+```
+
+---
+
+## 4. API contract
+
+No change.
+
+---
+
+## 5. Security notes
+
+`extractDomains` operates on backend-sanitised content (ADR-002). The fix changes only the split delimiter; it introduces no new parsing, no user input handling, and no DOM interaction. No security impact.
+
+---
+
+## 6. Consistency notes
+
+Follows the established utility function pattern in `utils/classContentParsers.ts`. No new patterns introduced.

--- a/dev-flow/engineering/architecture/PBI-019-experience-name-and-modifier-flow.md
+++ b/dev-flow/engineering/architecture/PBI-019-experience-name-and-modifier-flow.md
@@ -1,0 +1,63 @@
+# Flow Descriptor — PBI-019: Experience name and modifier fields
+
+**PBI:** PBI-019
+**ADR:** None required — follows established ADR-012 pattern
+**Date:** 2026-05-14
+
+---
+
+## 1. What this builds
+
+Splits each of the 5 experience rows in the character sheet's Experience section into two inputs: a free-text name field and a numeric modifier field (styled like the trait score inputs). The character state model is updated from `string[]` to `Array<{name: string; modifier: number | null}>`. No backend changes.
+
+---
+
+## 2. Component map
+
+| Component | Layer | Status | Change |
+|---|---|---|---|
+| `character.ts` | Frontend — types | Modified | `experience: string[]` → `experience: Array<{name: string; modifier: number \| null}>` |
+| `CharacterContext.tsx` | Frontend — state | Modified | Initial state updated; reducer handles separate `name`/`modifier` fields per row |
+| `useCharacterHope.ts` | Frontend — hook | Modified | `setExperience(index, value)` replaced by `setExperienceName(index, value: string)` and `setExperienceModifier(index, value: number \| null)` |
+| `ExperienceSection.tsx` | Frontend — component | Modified | Each row renders a `type="text"` name input and a `type="number"` modifier input side-by-side |
+
+---
+
+## 3. Data flow
+
+No server interaction. All state is local to `CharacterContext`.
+
+```
+User types in name field [row N]
+  → ExperienceSection: setExperienceName(N, value)
+  → useCharacterHope: dispatch SET_EXPERIENCE_NAME { index: N, value }
+  → reducer: experience[N].name = value
+  → re-render: name input reflects new value; modifier input unchanged
+
+User types in modifier field [row N]
+  → ExperienceSection: setExperienceModifier(N, parsedInt)
+  → useCharacterHope: dispatch SET_EXPERIENCE_MODIFIER { index: N, value }
+  → reducer: experience[N].modifier = value  (null if input is empty/NaN)
+  → re-render: modifier input reflects new value; name input unchanged
+```
+
+---
+
+## 4. API contract
+
+No API changes. Experience data is not persisted to the backend.
+
+---
+
+## 5. Security notes
+
+Both fields are plain local form inputs. The modifier field uses `type="number"` which the browser constrains to numeric input. No user-supplied data crosses a trust boundary. No security impact.
+
+---
+
+## 6. Consistency notes
+
+- Follows ADR-012 (React Context + useReducer) exactly: new action types `SET_EXPERIENCE_NAME` and `SET_EXPERIENCE_MODIFIER` are added to the existing reducer.
+- Modifier field uses `parseInt` with `null` fallback — identical to the pattern used in `TraitsSection` (`handleTraitChange`) and `DamageHealthSection` (`handleThresholdChange`).
+- The modifier field reuses `traits-section__score-input` CSS class (or a dedicated `experience-section__modifier-input` class with matching dimensions) per the approved Design Specification (PBI-019).
+- No new patterns, no new dependencies, no new components.

--- a/dev-flow/product/PBI-017-class-hp-slot-count.feature
+++ b/dev-flow/product/PBI-017-class-hp-slot-count.feature
@@ -1,0 +1,60 @@
+Feature: Class-specific HP slot count drives solid/dashed border rendering
+  As a player filling in my character sheet,
+  I want the number of solid HP boxes to reflect my chosen class,
+  So that my sheet accurately shows the correct HP structure as defined in the
+  Daggerheart rules, where different classes have different base hit point counts.
+  Backlog item: PBI-017
+
+  Background:
+    Given the character sheet is open
+
+  @smoke @frontend
+  Scenario: HP boxes reflect the selected class's starting hit point count
+    When the user selects "Bard" from the class dropdown
+    Then exactly 5 HP boxes have a solid border
+    And the remaining 5 HP boxes have a dashed border
+
+  @regression @frontend
+  Scenario: HP box borders update when a different class is selected
+    Given the user has selected "Bard" from the class dropdown
+    When the user selects "Guardian" from the class dropdown
+    Then exactly 7 HP boxes have a solid border
+    And the remaining 3 HP boxes have a dashed border
+
+  @regression @frontend
+  Scenario: HP boxes show a default when no class is selected
+    Given no class has been selected
+    Then exactly 6 HP boxes have a solid border
+    And the remaining 4 HP boxes have a dashed border
+
+  @regression @frontend
+  Scenario: Each class renders the correct number of solid HP boxes
+    When the user selects "Druid" from the class dropdown
+    Then exactly 6 HP boxes have a solid border
+    When the user selects "Ranger" from the class dropdown
+    Then exactly 6 HP boxes have a solid border
+    When the user selects "Rogue" from the class dropdown
+    Then exactly 6 HP boxes have a solid border
+    When the user selects "Seraph" from the class dropdown
+    Then exactly 7 HP boxes have a solid border
+    When the user selects "Sorcerer" from the class dropdown
+    Then exactly 6 HP boxes have a solid border
+    When the user selects "Warrior" from the class dropdown
+    Then exactly 6 HP boxes have a solid border
+    When the user selects "Wizard" from the class dropdown
+    Then exactly 5 HP boxes have a solid border
+
+  @regression @backend
+  Scenario: Class API response includes the starting HP slot count for Bard
+    When a request is made for the class with slug "bard"
+    Then the response includes a field "hpSlotCount" with value 5
+
+  @regression @backend
+  Scenario: Class API response includes the starting HP slot count for Guardian
+    When a request is made for the class with slug "guardian"
+    Then the response includes a field "hpSlotCount" with value 7
+
+  @regression @backend
+  Scenario: All class API responses include a non-zero hpSlotCount
+    When a request is made for each class in the system
+    Then every response includes a field "hpSlotCount" with a value greater than 0

--- a/dev-flow/product/PBI-018-domain-badges-fix.feature
+++ b/dev-flow/product/PBI-018-domain-badges-fix.feature
@@ -1,0 +1,44 @@
+Feature: Domain badges display after class selection
+  As a player filling in my character sheet,
+  I want to see my class's domain names appear in the header after selecting a class,
+  So that I know which domains I have access to without consulting a separate rulebook.
+  Backlog item: PBI-018
+
+  Background:
+    Given the character sheet is open
+
+  @regression @smoke @frontend
+  Scenario: Domain badges render correctly after selecting a class
+    When the user selects "Bard" from the class dropdown
+    Then two domain badges are displayed: "Grace" and "Codex"
+    And the placeholder text "Select a class to see domains" is no longer visible
+
+  @regression @frontend
+  Scenario: Domain badges update when a different class is selected
+    Given the user has selected "Bard" from the class dropdown
+    When the user selects "Guardian" from the class dropdown
+    Then two domain badges are displayed: "Valor" and "Blade"
+    And no badges for "Grace" or "Codex" are visible
+
+  @regression @frontend
+  Scenario: Placeholder is shown when no class is selected
+    Given no class has been selected
+    Then the placeholder text "Select a class to see domains" is displayed
+    And no domain badges are visible
+
+  @regression @frontend
+  Scenario: Domain badges render for all supported classes
+    When the user selects "Druid" from the class dropdown
+    Then two domain badges are displayed: "Sage" and "Arcana"
+    When the user selects "Ranger" from the class dropdown
+    Then two domain badges are displayed: "Bone" and "Sage"
+    When the user selects "Rogue" from the class dropdown
+    Then two domain badges are displayed: "Midnight" and "Grace"
+    When the user selects "Seraph" from the class dropdown
+    Then two domain badges are displayed: "Splendor" and "Valor"
+    When the user selects "Sorcerer" from the class dropdown
+    Then two domain badges are displayed: "Arcana" and "Midnight"
+    When the user selects "Warrior" from the class dropdown
+    Then two domain badges are displayed: "Blade" and "Bone"
+    When the user selects "Wizard" from the class dropdown
+    Then two domain badges are displayed: "Codex" and "Splendor"

--- a/dev-flow/product/PBI-019-experience-name-and-modifier.feature
+++ b/dev-flow/product/PBI-019-experience-name-and-modifier.feature
@@ -1,0 +1,44 @@
+Feature: Experience lines have separate name and modifier fields
+  As a player filling in my character sheet,
+  I want each experience line to have a name field and a numeric modifier field,
+  So that I can record experiences in the structured form the game uses,
+  such as "Charlatan" with 2, matching how experiences are referenced during play.
+  Backlog item: PBI-019
+
+  Background:
+    Given the character sheet is open
+
+  @smoke @frontend
+  Scenario: Each experience line shows a name field and a modifier field
+    Then the experience section displays 5 rows
+    And each row has a name input field
+    And each row has a modifier input field
+
+  @regression @frontend
+  Scenario: Player can enter an experience name and modifier
+    When the user enters "Charlatan" in the name field of experience line 1
+    And the user enters 2 in the modifier field of experience line 1
+    Then the name field of experience line 1 shows "Charlatan"
+    And the modifier field of experience line 1 shows 2
+
+  @regression @frontend
+  Scenario: Player can enter a negative modifier
+    When the user enters "Coward" in the name field of experience line 1
+    And the user enters -1 in the modifier field of experience line 1
+    Then the modifier field of experience line 1 shows -1
+
+  @regression @frontend
+  Scenario: Name and modifier fields are independent across experience lines
+    When the user enters "Sailor" in the name field of experience line 2
+    And the user enters 1 in the modifier field of experience line 2
+    And the user enters "Acrobat" in the name field of experience line 3
+    And the user enters 3 in the modifier field of experience line 3
+    Then the name field of experience line 2 shows "Sailor"
+    And the modifier field of experience line 2 shows 1
+    And the name field of experience line 3 shows "Acrobat"
+    And the modifier field of experience line 3 shows 3
+
+  @regression @frontend
+  Scenario: Experience fields are empty on initial load
+    Then all experience name fields are empty
+    And all experience modifier fields are empty

--- a/frontend/e2e/pages/AppPage.ts
+++ b/frontend/e2e/pages/AppPage.ts
@@ -408,20 +408,60 @@ export class AppPage {
     }
 
     async getExperienceLineCount(): Promise<number> {
-        await this.page.waitForSelector('[data-testid^="experience-line-"]', { timeout: 5000 });
-        return this.page.$$eval('[data-testid^="experience-line-"]', (els) => els.length);
+        await this.page.waitForSelector('.experience-section__row', { timeout: 5000 });
+        return this.page.$$eval('.experience-section__row', (els) => els.length);
     }
 
     async fillExperienceLine(lineNumber: number, value: string): Promise<void> {
-        const input = this.page.locator(`[data-testid="experience-line-${lineNumber}"]`);
+        const input = this.page.locator(`[data-testid="experience-line-${lineNumber}-name"]`);
         await input.waitFor({ timeout: 5000 });
         await input.fill(value);
     }
 
     async getExperienceLineValue(lineNumber: number): Promise<string> {
-        const input = this.page.locator(`[data-testid="experience-line-${lineNumber}"]`);
+        const input = this.page.locator(`[data-testid="experience-line-${lineNumber}-name"]`);
         await input.waitFor({ timeout: 5000 });
         return input.inputValue();
+    }
+
+    async fillExperienceNameField(lineNumber: number, value: string): Promise<void> {
+        const input = this.page.locator(`[data-testid="experience-line-${lineNumber}-name"]`);
+        await input.waitFor({ timeout: 5000 });
+        await input.fill(value);
+    }
+
+    async fillExperienceModifierField(lineNumber: number, value: string): Promise<void> {
+        const input = this.page.locator(`[data-testid="experience-line-${lineNumber}-modifier"]`);
+        await input.waitFor({ timeout: 5000 });
+        await input.fill(value);
+    }
+
+    async getExperienceNameValue(lineNumber: number): Promise<string> {
+        const input = this.page.locator(`[data-testid="experience-line-${lineNumber}-name"]`);
+        await input.waitFor({ timeout: 5000 });
+        return input.inputValue();
+    }
+
+    async getExperienceModifierValue(lineNumber: number): Promise<string> {
+        const input = this.page.locator(`[data-testid="experience-line-${lineNumber}-modifier"]`);
+        await input.waitFor({ timeout: 5000 });
+        return input.inputValue();
+    }
+
+    async allExperienceNameFieldsEmpty(): Promise<boolean> {
+        for (let i = 1; i <= 5; i++) {
+            const val = await this.getExperienceNameValue(i);
+            if (val !== '') return false;
+        }
+        return true;
+    }
+
+    async allExperienceModifierFieldsEmpty(): Promise<boolean> {
+        for (let i = 1; i <= 5; i++) {
+            const val = await this.getExperienceModifierValue(i);
+            if (val !== '') return false;
+        }
+        return true;
     }
 
     async getGoldSlotCount(groupLabel: string): Promise<number> {
@@ -707,5 +747,46 @@ export class AppPage {
             '.character-sheet__section h2',
             (el) => window.getComputedStyle(el).color,
         );
+    }
+
+    // =============================================================================
+    // Domain badge helpers (PBI-018)
+    // =============================================================================
+
+    async domainBadgesContain(domain1: string, domain2: string): Promise<boolean> {
+        await this.page.waitForSelector('[data-testid="class-badges"]', { timeout: 10000 });
+        const badges = await this.getDomainBadgeTexts();
+        return badges.includes(domain1) && badges.includes(domain2);
+    }
+
+    async isPlaceholderTextVisible(text: string): Promise<boolean> {
+        await this.page.waitForSelector('[data-testid="class-badges"]', { timeout: 10000 });
+        const placeholder = this.page.locator('.class-header__badge--placeholder');
+        const count = await placeholder.count();
+        if (count === 0) return false;
+        const content = await placeholder.textContent();
+        return (content ?? '').includes(text);
+    }
+
+    async noDomainBadgesVisible(): Promise<boolean> {
+        await this.page.waitForSelector('[data-testid="class-badges"]', { timeout: 10000 });
+        const count = await this.page.$$eval(
+            '[data-testid="class-badges"] .class-header__badge--domain',
+            (els) => els.length,
+        );
+        return count === 0;
+    }
+
+    async noBadgesForDomains(domain1: string, domain2: string): Promise<boolean> {
+        const badges = await this.getDomainBadgeTexts();
+        return !badges.includes(domain1) && !badges.includes(domain2);
+    }
+
+    // =============================================================================
+    // HP box type helpers (PBI-017)
+    // =============================================================================
+
+    async countHpBoxesByType(slotType: 'solid' | 'dashed'): Promise<number> {
+        return this.countSlotsByType('hp-tracker', slotType);
     }
 }

--- a/frontend/e2e/steps/appSteps.ts
+++ b/frontend/e2e/steps/appSteps.ts
@@ -1369,3 +1369,124 @@ Then('the Class Feature section spans both columns', async function (this: Custo
     const appPage = new AppPage(this.page);
     expect(await appPage.classFeatureSectionSpansBothColumns()).toBe(true);
 });
+
+// =============================================================================
+// Shared background step (PBI-017, PBI-018, PBI-019)
+// =============================================================================
+
+Given('the character sheet is open', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    await appPage.navigateToCharacterSheet();
+    await appPage.waitForCharacterSheet();
+});
+
+When('the user selects {string} from the class dropdown', async function (this: CustomWorld, className: string) {
+    const appPage = new AppPage(this.page);
+    await appPage.selectDropdownOption('Class', className);
+});
+
+Given('the user has selected {string} from the class dropdown', async function (this: CustomWorld, className: string) {
+    const appPage = new AppPage(this.page);
+    await appPage.selectDropdownOption('Class', className);
+});
+
+// =============================================================================
+// PBI-017 — Class HP slot count
+// =============================================================================
+
+Then('exactly {int} HP boxes have a solid border', async function (this: CustomWorld, expectedCount: number) {
+    const appPage = new AppPage(this.page);
+    const count = await appPage.countHpBoxesByType('solid');
+    expect(count).toBe(expectedCount);
+});
+
+Then('the remaining {int} HP boxes have a dashed border', async function (this: CustomWorld, expectedCount: number) {
+    const appPage = new AppPage(this.page);
+    const count = await appPage.countHpBoxesByType('dashed');
+    expect(count).toBe(expectedCount);
+});
+
+// =============================================================================
+// PBI-018 — Domain badges display
+// =============================================================================
+
+Then('two domain badges are displayed: {string} and {string}', async function (this: CustomWorld, domain1: string, domain2: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.domainBadgesContain(domain1, domain2)).toBe(true);
+});
+
+Then('the placeholder text {string} is no longer visible', async function (this: CustomWorld, text: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.isPlaceholderTextVisible(text)).toBe(false);
+});
+
+Then('the placeholder text {string} is displayed', async function (this: CustomWorld, text: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.isPlaceholderTextVisible(text)).toBe(true);
+});
+
+Then('no domain badges are visible', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.noDomainBadgesVisible()).toBe(true);
+});
+
+Then('no badges for {string} or {string} are visible', async function (this: CustomWorld, domain1: string, domain2: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.noBadgesForDomains(domain1, domain2)).toBe(true);
+});
+
+// =============================================================================
+// PBI-019 — Experience name and modifier fields
+// =============================================================================
+
+Then('the experience section displays {int} rows', async function (this: CustomWorld, expectedCount: number) {
+    const appPage = new AppPage(this.page);
+    const count = await appPage.getExperienceLineCount();
+    expect(count).toBe(expectedCount);
+});
+
+Then('each row has a name input field', async function (this: CustomWorld) {
+    for (let i = 1; i <= 5; i++) {
+        const input = this.page.locator(`[data-testid="experience-line-${i}-name"]`);
+        expect(await input.count()).toBe(1);
+    }
+});
+
+Then('each row has a modifier input field', async function (this: CustomWorld) {
+    for (let i = 1; i <= 5; i++) {
+        const input = this.page.locator(`[data-testid="experience-line-${i}-modifier"]`);
+        expect(await input.count()).toBe(1);
+    }
+});
+
+When('the user enters {string} in the name field of experience line {int}', async function (this: CustomWorld, value: string, lineNumber: number) {
+    const appPage = new AppPage(this.page);
+    await appPage.fillExperienceNameField(lineNumber, value);
+});
+
+When('the user enters {int} in the modifier field of experience line {int}', async function (this: CustomWorld, value: number, lineNumber: number) {
+    const appPage = new AppPage(this.page);
+    await appPage.fillExperienceModifierField(lineNumber, String(value));
+});
+
+Then('the name field of experience line {int} shows {string}', async function (this: CustomWorld, lineNumber: number, expectedValue: string) {
+    const appPage = new AppPage(this.page);
+    const actual = await appPage.getExperienceNameValue(lineNumber);
+    expect(actual).toBe(expectedValue);
+});
+
+Then('the modifier field of experience line {int} shows {int}', async function (this: CustomWorld, lineNumber: number, expectedValue: number) {
+    const appPage = new AppPage(this.page);
+    const actual = await appPage.getExperienceModifierValue(lineNumber);
+    expect(actual).toBe(String(expectedValue));
+});
+
+Then('all experience name fields are empty', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.allExperienceNameFieldsEmpty()).toBe(true);
+});
+
+Then('all experience modifier fields are empty', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.allExperienceModifierFieldsEmpty()).toBe(true);
+});

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1197,6 +1197,16 @@ main {
   gap: 0.5rem;
 }
 
+.experience-section__row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.experience-section__row .experience-section__line-input {
+  flex: 1;
+}
+
 /* ============================================================
    Gold Section
    ============================================================ */

--- a/frontend/src/features/character-sheet/components/ClassHeader.tsx
+++ b/frontend/src/features/character-sheet/components/ClassHeader.tsx
@@ -33,8 +33,12 @@ function ClassHeader(): React.ReactElement {
 
   const handleClassChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value = e.target.value;
-    // When class changes, clear subclass to prevent stale selection.
-    setIdentity({ classSlug: value !== '' ? value : null, subclassSlug: null });
+    const cls = value !== '' ? classes.find((c) => c.slug === value) : undefined;
+    setIdentity({
+      classSlug: value !== '' ? value : null,
+      subclassSlug: null,
+      hpSolidCount: cls?.hpSlotCount ?? 6,
+    });
   };
 
   const handleHeritageChange = (e: React.ChangeEvent<HTMLSelectElement>) => {

--- a/frontend/src/features/character-sheet/components/DamageHealthSection.tsx
+++ b/frontend/src/features/character-sheet/components/DamageHealthSection.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useCharacterHealth } from '../hooks/useCharacterHealth';
 
-const HP_SOLID_COUNT = 6;
 const STRESS_SOLID_COUNT = 4;
 
 function DamageHealthSection(): React.ReactElement {
   const {
+    hpSolidCount,
     damageThresholds,
     hpSlots,
     stressSlots,
@@ -98,7 +98,7 @@ function DamageHealthSection(): React.ReactElement {
         <span className="damage-health-section__tracker-label">HP</span>
         <div className="damage-health-section__slots">
           {hpSlots.map((isMarked, index) => {
-            const isDashed = index >= HP_SOLID_COUNT;
+            const isDashed = index >= hpSolidCount;
             return (
               <button
                 key={index}

--- a/frontend/src/features/character-sheet/components/ExperienceSection.tsx
+++ b/frontend/src/features/character-sheet/components/ExperienceSection.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { useCharacterHope } from '../hooks/useCharacterHope';
 
 function ExperienceSection(): React.ReactElement {
-  const { experience, setExperience } = useCharacterHope();
+  const { experience, setExperienceName, setExperienceModifier } = useCharacterHope();
+
+  function handleModifierChange(index: number, rawValue: string): void {
+    const parsed = parseInt(rawValue, 10);
+    setExperienceModifier(index, isNaN(parsed) ? null : parsed);
+  }
 
   return (
     <section
@@ -13,16 +18,25 @@ function ExperienceSection(): React.ReactElement {
       <h2>Experience</h2>
 
       <div className="experience-section__lines">
-        {experience.map((line, index) => (
-          <input
-            key={index}
-            type="text"
-            className="experience-section__line-input"
-            aria-label={`Experience line ${index + 1}`}
-            data-testid={`experience-line-${index + 1}`}
-            value={line}
-            onChange={(e) => setExperience(index, e.target.value)}
-          />
+        {experience.map((entry, index) => (
+          <div key={index} className="experience-section__row">
+            <input
+              type="text"
+              className="experience-section__line-input"
+              aria-label={`Experience line ${index + 1} name`}
+              data-testid={`experience-line-${index + 1}-name`}
+              value={entry.name}
+              onChange={(e) => setExperienceName(index, e.target.value)}
+            />
+            <input
+              type="number"
+              className="traits-section__score-input"
+              aria-label={`Experience line ${index + 1} modifier`}
+              data-testid={`experience-line-${index + 1}-modifier`}
+              value={entry.modifier ?? ''}
+              onChange={(e) => handleModifierChange(index, e.target.value)}
+            />
+          </div>
         ))}
       </div>
     </section>

--- a/frontend/src/features/character-sheet/context/CharacterContext.tsx
+++ b/frontend/src/features/character-sheet/context/CharacterContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useReducer } from 'react';
-import type { CharacterState, CharacterAction } from '../types/character';
+import type { CharacterState, CharacterAction, ExperienceEntry } from '../types/character';
 
 const initialState: CharacterState = {
   name: '',
@@ -21,13 +21,14 @@ const initialState: CharacterState = {
   armorScore: null,
   armorSlots: Array(6).fill(false) as boolean[],
 
+  hpSolidCount: 6,
   damageThresholds: { minor: null, major: null, severe: null },
   hpSlots: Array(10).fill(false) as boolean[],
   stressSlots: Array(8).fill(false) as boolean[],
 
   hopeDiamonds: Array(6).fill(false) as boolean[],
   proficiencyPips: [true, false, false, false, false, false],
-  experience: Array(5).fill('') as string[],
+  experience: Array(5).fill(null).map((): ExperienceEntry => ({ name: '', modifier: null })),
   gold: { handfuls: 0, bags: 0, chest: 0 },
 
   primaryWeapon: null,
@@ -92,9 +93,16 @@ function characterReducer(state: CharacterState, action: CharacterAction): Chara
     case 'TOGGLE_PROFICIENCY_PIP':
       return { ...state, proficiencyPips: gaugeToggle(state.proficiencyPips, action.payload) };
 
-    case 'SET_EXPERIENCE': {
+    case 'SET_EXPERIENCE_NAME': {
       const experience = state.experience.map((entry, i) =>
-        i === action.payload.index ? action.payload.value : entry
+        i === action.payload.index ? { ...entry, name: action.payload.value } : entry
+      );
+      return { ...state, experience };
+    }
+
+    case 'SET_EXPERIENCE_MODIFIER': {
+      const experience = state.experience.map((entry, i) =>
+        i === action.payload.index ? { ...entry, modifier: action.payload.value } : entry
       );
       return { ...state, experience };
     }

--- a/frontend/src/features/character-sheet/hooks/useCharacterHealth.ts
+++ b/frontend/src/features/character-sheet/hooks/useCharacterHealth.ts
@@ -3,6 +3,7 @@ import { useCharacterContext } from '../context/CharacterContext';
 import type { CharacterState } from '../types/character';
 
 interface UseCharacterHealthResult {
+  hpSolidCount: number;
   damageThresholds: CharacterState['damageThresholds'];
   hpSlots: boolean[];
   stressSlots: boolean[];
@@ -36,6 +37,7 @@ export function useCharacterHealth(): UseCharacterHealthResult {
   );
 
   return {
+    hpSolidCount: state.hpSolidCount,
     damageThresholds: state.damageThresholds,
     hpSlots: state.hpSlots,
     stressSlots: state.stressSlots,

--- a/frontend/src/features/character-sheet/hooks/useCharacterHope.ts
+++ b/frontend/src/features/character-sheet/hooks/useCharacterHope.ts
@@ -1,15 +1,16 @@
 import { useCallback } from 'react';
 import { useCharacterContext } from '../context/CharacterContext';
-import type { CharacterState } from '../types/character';
+import type { CharacterState, ExperienceEntry } from '../types/character';
 
 interface UseCharacterHopeResult {
   hopeDiamonds: boolean[];
   proficiencyPips: boolean[];
-  experience: string[];
+  experience: ExperienceEntry[];
   gold: CharacterState['gold'];
   toggleHopeDiamond: (index: number) => void;
   toggleProficiencyPip: (index: number) => void;
-  setExperience: (index: number, value: string) => void;
+  setExperienceName: (index: number, value: string) => void;
+  setExperienceModifier: (index: number, value: number | null) => void;
   setGold: (patch: Partial<CharacterState['gold']>) => void;
 }
 
@@ -30,9 +31,16 @@ export function useCharacterHope(): UseCharacterHopeResult {
     [dispatch]
   );
 
-  const setExperience = useCallback(
+  const setExperienceName = useCallback(
     (index: number, value: string) => {
-      dispatch({ type: 'SET_EXPERIENCE', payload: { index, value } });
+      dispatch({ type: 'SET_EXPERIENCE_NAME', payload: { index, value } });
+    },
+    [dispatch]
+  );
+
+  const setExperienceModifier = useCallback(
+    (index: number, value: number | null) => {
+      dispatch({ type: 'SET_EXPERIENCE_MODIFIER', payload: { index, value } });
     },
     [dispatch]
   );
@@ -51,7 +59,8 @@ export function useCharacterHope(): UseCharacterHopeResult {
     gold: state.gold,
     toggleHopeDiamond,
     toggleProficiencyPip,
-    setExperience,
+    setExperienceName,
+    setExperienceModifier,
     setGold,
   };
 }

--- a/frontend/src/features/character-sheet/hooks/useCharacterIdentity.ts
+++ b/frontend/src/features/character-sheet/hooks/useCharacterIdentity.ts
@@ -1,7 +1,7 @@
 import { useCharacterContext } from '../context/CharacterContext';
 import type { CharacterState } from '../types/character';
 
-type IdentityFields = Pick<CharacterState, 'name' | 'pronouns' | 'classSlug' | 'heritageSlug' | 'subclassSlug' | 'level'>;
+type IdentityFields = Pick<CharacterState, 'name' | 'pronouns' | 'classSlug' | 'heritageSlug' | 'subclassSlug' | 'level' | 'hpSolidCount'>;
 
 interface UseCharacterIdentityResult extends IdentityFields {
   setName: (value: string) => void;
@@ -27,6 +27,7 @@ export function useCharacterIdentity(): UseCharacterIdentityResult {
     heritageSlug: state.heritageSlug,
     subclassSlug: state.subclassSlug,
     level: state.level,
+    hpSolidCount: state.hpSolidCount,
     setName: (value) => setIdentity({ name: value }),
     setPronouns: (value) => setIdentity({ pronouns: value }),
     setClassSlug: (value) => setIdentity({ classSlug: value }),

--- a/frontend/src/features/character-sheet/types/character.ts
+++ b/frontend/src/features/character-sheet/types/character.ts
@@ -1,3 +1,8 @@
+export interface ExperienceEntry {
+  name: string;
+  modifier: number | null;
+}
+
 export interface WeaponEntry {
   slug: string;
   name: string;
@@ -42,15 +47,16 @@ export interface CharacterState {
   armorScore: number | null;
   armorSlots: boolean[];
 
-  // Health (PBI-011)
+  // Health (PBI-011, PBI-017)
+  hpSolidCount: number;
   damageThresholds: { minor: number | null; major: number | null; severe: number | null };
   hpSlots: boolean[];
   stressSlots: boolean[];
 
-  // Hope & Gold (PBI-011)
+  // Hope & Gold (PBI-011, PBI-019)
   hopeDiamonds: boolean[];
   proficiencyPips: boolean[];
-  experience: string[];
+  experience: ExperienceEntry[];
   gold: { handfuls: number; bags: number; chest: number };
 
   // Equipment (PBI-012)
@@ -62,7 +68,7 @@ export interface CharacterState {
 }
 
 export type CharacterAction =
-  | { type: 'SET_IDENTITY'; payload: Partial<Pick<CharacterState, 'name' | 'pronouns' | 'classSlug' | 'heritageSlug' | 'subclassSlug' | 'level'>> }
+  | { type: 'SET_IDENTITY'; payload: Partial<Pick<CharacterState, 'name' | 'pronouns' | 'classSlug' | 'heritageSlug' | 'subclassSlug' | 'level' | 'hpSolidCount'>> }
   | { type: 'SET_TRAIT'; payload: { trait: keyof CharacterState['traits']; value: number | null } }
   | { type: 'SET_EVASION'; payload: number }
   | { type: 'SET_ARMOR_SCORE'; payload: number | null }
@@ -72,7 +78,8 @@ export type CharacterAction =
   | { type: 'TOGGLE_STRESS_SLOT'; payload: number }
   | { type: 'TOGGLE_HOPE_DIAMOND'; payload: number }
   | { type: 'TOGGLE_PROFICIENCY_PIP'; payload: number }
-  | { type: 'SET_EXPERIENCE'; payload: { index: number; value: string } }
+  | { type: 'SET_EXPERIENCE_NAME'; payload: { index: number; value: string } }
+  | { type: 'SET_EXPERIENCE_MODIFIER'; payload: { index: number; value: number | null } }
   | { type: 'SET_GOLD'; payload: Partial<CharacterState['gold']> }
   | { type: 'SET_PRIMARY_WEAPON'; payload: WeaponEntry | null }
   | { type: 'SET_SECONDARY_WEAPON'; payload: WeaponEntry | null }

--- a/frontend/src/features/character-sheet/utils/classContentParsers.ts
+++ b/frontend/src/features/character-sheet/utils/classContentParsers.ts
@@ -2,23 +2,26 @@
  * Extracts the two domain names from a CLASSES SrdItem content HTML string.
  *
  * The domain line appears inside a blockquote as:
- *   <strong>• DOMAINS:</strong> Domain1 &amp; Domain2
+ *   <strong>• DOMAINS:</strong> <a href="...">Domain1</a> &amp; <a href="...">Domain2</a>
  *
  * Returns an array of (up to two) domain name strings, or an empty array
  * if the pattern is not found.
  */
 export function extractDomains(contentHtml: string): string[] {
-  // Match the text following "DOMAINS:" up to the next <br or <strong or </p
-  const match = contentHtml.match(/DOMAINS:<\/strong>\s*([^<]+)/i);
-  if (!match) return [];
+  // Capture everything between DOMAINS:</strong> and the next <br
+  const sectionMatch = contentHtml.match(/DOMAINS:<\/strong>\s*([\s\S]*?)<br/i);
+  if (!sectionMatch) return [];
 
-  const raw = match[1];
-  // Decode HTML entity for ampersand and split on " & "
-  const decoded = raw.replace(/&amp;/g, '&');
-  return decoded
-    .split('&')
-    .map((name) => name.trim())
-    .filter((name) => name.length > 0);
+  const sectionHtml = sectionMatch[1];
+  // Extract the visible text from each <a> tag
+  const domains: string[] = [];
+  const linkPattern = /<a[^>]*>([^<]+)<\/a>/gi;
+  let linkMatch;
+  while ((linkMatch = linkPattern.exec(sectionHtml)) !== null) {
+    const name = linkMatch[1].trim();
+    if (name.length > 0) domains.push(name);
+  }
+  return domains;
 }
 
 /**

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -9,6 +9,7 @@ export interface SrdItem {
   recallCost?: string | number;
   subtype?: string;
   tags?: string[];
+  hpSlotCount?: number;
 }
 
 export interface SearchResponse {


### PR DESCRIPTION
## Summary

- **PBI-017**: Backend parses `STARTING HIT POINTS` from class SRD content at ingestion and stores it as `hpSlotCount` on `SrdItem`. Frontend wires `hpSolidCount` through `CharacterContext` into `DamageHealthSection`, replacing the hardcoded constant of 6.
- **PBI-018 (bug fix)**: `extractDomains` was stopping at the first `<a` tag. Fixed to capture the full HTML section between `DOMAINS:</strong>` and `<br`, then extract link text from `<a>` elements.
- **PBI-019**: Experience lines now have separate name (free text) and numeric modifier fields, matching the structured form used during play. `ExperienceEntry` type introduced; state, reducer, hook, component, and CSS all updated.

## Test plan

- [ ] Backend: `mvn test` — `SrdServiceTest` unit tests for `enrichClassItem`; `HpSlotCountStepDefs` Cucumber acceptance scenarios
- [ ] Frontend e2e: `npm run test:e2e` — new step definitions for PBI-017 HP box scenarios, PBI-018 domain badge scenarios, PBI-019 experience field scenarios
- [ ] Verify class selection updates solid/dashed HP box split correctly (Bard→5 solid, Guardian→7 solid, default→6)
- [ ] Verify domain badges render after class selection and update on class change
- [ ] Verify experience rows show name + modifier inputs; modifier accepts negative integers

🤖 Generated with [Claude Code](https://claude.com/claude-code)