### PR TITLE
fix(PBI-017): cast Map body to Map<String,Object> in HpSlotCountStepDefs

### DIFF
--- a/backend/src/test/java/com/dhsrd/cucumber/steps/HpSlotCountStepDefs.java
+++ b/backend/src/test/java/com/dhsrd/cucumber/steps/HpSlotCountStepDefs.java
@@ -30,9 +30,10 @@ public class HpSlotCountStepDefs {
     }
 
     @Then("the response includes a field {string} with value {int}")
+    @SuppressWarnings("unchecked")
     public void should_have_field_with_value(String field, int expectedValue) {
         assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
-        Map<?, ?> body = response.getBody();
+        Map<String, Object> body = (Map<String, Object>) response.getBody();
         assertThat(body).isNotNull();
         assertThat(body).containsKey(field);
         assertThat(((Number) body.get(field)).intValue()).isEqualTo(expectedValue);
@@ -49,10 +50,11 @@ public class HpSlotCountStepDefs {
     }
 
     @Then("every response includes a field {string} with a value greater than 0")
+    @SuppressWarnings("unchecked")
     public void should_all_have_field_greater_than_zero(String field) {
         for (ResponseEntity<Map> r : allClassResponses) {
             assertThat(r.getStatusCode().is2xxSuccessful()).isTrue();
-            Map<?, ?> body = r.getBody();
+            Map<String, Object> body = (Map<String, Object>) r.getBody();
             assertThat(body).isNotNull();
             assertThat(body).containsKey(field);
             assertThat(((Number) body.get(field)).intValue()).isGreaterThan(0);


### PR DESCRIPTION
## Summary

- `HpSlotCountStepDefs` used `Map<?, ?>` for the response body, which caused `assertThat(body).containsKey(field)` to fail compilation — AssertJ inferred the key type as `capture#1 of ?` rather than `String`.
- Fix: cast to `Map<String, Object>` with `@SuppressWarnings("unchecked")`, matching the pattern already used in `SearchStepDefs.java`.

## Test plan

- [ ] `mvn test` compiles and the backend starts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)