### PR TITLE
fix(PBI-017): store and return hpSlotCount in Lucene index

### DIFF
--- a/backend/src/main/java/com/dhsrd/search/LuceneService.java
+++ b/backend/src/main/java/com/dhsrd/search/LuceneService.java
@@ -42,6 +42,7 @@ public class LuceneService {
             d.add(new IntPoint("level", it.getLevel()));
             d.add(new StoredField("level_store", it.getLevel()));
         }
+        if (it.getHpSlotCount() != null) d.add(new StoredField("hpSlotCount", it.getHpSlotCount()));
         return d;
     }
 
@@ -124,6 +125,7 @@ public class LuceneService {
                 m.put("type", d.get("type"));
                 m.put("subtype", d.get("subtype"));
                 m.put("level", d.get("level_store") == null ? null : Integer.valueOf(d.get("level_store")));
+                m.put("hpSlotCount", d.get("hpSlotCount") == null ? null : Integer.valueOf(d.get("hpSlotCount")));
                 m.put("tags", Arrays.asList(d.getValues("tag")));
                 m.put("score", sd[i].score);
                 hits.add(m);


### PR DESCRIPTION
## Bug

HP bar always showed 6 solid boxes regardless of selected class. PBI-017's `hpSolidCount` feature was completely non-functional.

## Root cause

`LuceneService.toDoc()` stored every other field on `SrdItem` in the Lucene document but never added `hpSlotCount`. The `search()` result builder likewise never read it back. So `useSrdClasses` always returned items where `hpSlotCount` was `undefined`, and `cls?.hpSlotCount ?? 6` fell back to 6 for every class.

## Fix

- Add `StoredField("hpSlotCount", ...)` in `toDoc()` (matches the pattern for `level_store`)
- Read it back in the search result map with the same null-safe `Integer.valueOf` pattern used for `level`

Two lines changed, no new dependencies.

## Test plan

- [ ] Start backend — Lucene index is rebuilt on first startup after clearing `target/lucene-data`
- [ ] Select Bard → 5 solid HP boxes, 5 dashed
- [ ] Select Guardian → 7 solid HP boxes, 3 dashed
- [ ] Select no class → 6 solid HP boxes (default)
- [ ] Existing `@backend` scenarios in `PBI-017-class-hp-slot-count.feature` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)