### PR TITLE
feat: UI consolidation — nav dropdown, identity/traits layout, inline thresholds (PBI-020–022)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,9 @@ Determine what you're being asked to do, then read the corresponding guideline f
 
 ## Current State
 
-**Active increment:** Character Sheet — class HP count, domain badges fix, experience fields (PBI-017–019).
+**Active increment:** UI consolidation — nav dropdown, identity/traits layout, inline thresholds (PBI-020–022) — all PBIs complete.
 
-**Stage:** PBI-017–019 complete — implementation, tests, and e2e step definitions done; pending PR merge.
+**Stage:** All PBIs complete — Increment validation in progress
 
 **PBI status:**
 - `PBI-001` ✅ Complete
@@ -89,8 +89,11 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - `PBI-017` ✅ Complete — backend parses `STARTING HIT POINTS` at ingestion into `hpSlotCount`; frontend wires `hpSolidCount` through context into `DamageHealthSection`
 - `PBI-018` ✅ Complete — `extractDomains` fixed to capture `<a>` link text instead of stopping at first HTML tag
 - `PBI-019` ✅ Complete — experience lines split into separate name (text) and modifier (number) fields; `ExperienceEntry` type, reducer, hook, component, and CSS updated
+- `PBI-020` ✅ Complete — nav restructured into primary row (Compendium + Character Sheet buttons with diamond decorations) and secondary row (SRD category links); route-aware open/closed state
+- `PBI-021` ✅ Complete — character sheet identity row (`ClassHeader`) and traits row (`TraitsSection`) moved to full-width rows above the two-column grid; traits grid changed to `repeat(6, 1fr)`
+- `PBI-022` ✅ Complete — damage thresholds rendered as inline single row with two inputs; `severe` field removed from `DamageThresholds` state
 
-**Feature files:** `dev-flow/product/`
+**Feature files:** All complete ✅ (`dev-flow/product/`)
 - `PBI-001-security-baseline.feature` ✅
 - `PBI-002-backend-service-layer.feature` ✅
 - `PBI-003-backend-test-infrastructure.feature` ✅
@@ -110,8 +113,9 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - `PBI-017-class-hp-slot-count.feature` ✅
 - `PBI-018-domain-badges-fix.feature` ✅
 - `PBI-019-experience-name-and-modifier.feature` ✅
-
-**Priority order:** — awaiting increment validation
+- `PBI-020-nav-compendium-dropdown.feature` ✅
+- `PBI-021-character-sheet-identity-traits-layout.feature` ✅
+- `PBI-022-damage-thresholds-inline.feature` ✅
 
 **Key constraints:**
 - Step-def method naming convention (`should_/when_`) is established as exempt for BDD step definition methods (applies only to `@Test` JUnit methods).
@@ -129,6 +133,9 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - Experience lines (PBI-019): each row has `data-testid="experience-line-{N}-name"` and `data-testid="experience-line-{N}-modifier"`. `AppPage.getExperienceLineCount()` counts `.experience-section__row` elements; `fillExperienceLine` / `getExperienceLineValue` target the `-name` input.
 - HP solid/dashed split (PBI-017): `hpSolidCount` lives in `CharacterState` (default 6); set via `SET_IDENTITY` when class changes in `ClassHeader`. `useCharacterHealth` exposes it; `DamageHealthSection` uses it directly.
 - Domain badges (PBI-018): `extractDomains` in `classContentParsers.ts` parses `<a>` tags from the HTML section between `DOMAINS:</strong>` and `<br`. Domain names come from link text, not plain text nodes.
+- Nav (PBI-020): `isCompendiumOpen` state in `App.tsx`; open on all routes except `/character-sheet`; implemented via conditional rendering (DOM removal) rather than `display:none` — intentional deviation from design spec, documented in code comment.
+- Character sheet layout (PBI-021): `ClassHeader` renders in `.character-sheet__identity-row`; `TraitsSection` renders in `.character-sheet__traits-row` — both are full-width wrapper divs above `.character-sheet__columns`, not inside the column grid. Traits internal grid is `repeat(6, 1fr)`; collapses to `repeat(3, 1fr)` at ≤768px and `repeat(2, 1fr)` at ≤480px.
+- Damage thresholds (PBI-022): `DamageThresholds` type is `{ minor: number | null; major: number | null }` — `severe` field removed. Inline row has `data-testid="damage-thresholds-inline"`; inputs are `data-testid="threshold-minor"` and `data-testid="threshold-major"`.
 - Version control: all work happens on `increment/<slug>` or `fix/PBI-XXX-<slug>` branches in the main working tree. No git worktrees (removed from guidelines 2026-05-14).
 
 **Technical debt:** `dev-flow/product/technical-debt-backlog.md`
@@ -153,7 +160,7 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - `ADR-013-weapon-armor-srd-item-types.md` — WEAPONS/ARMOR as structured SrdItem types in srd.json; HTML-parsing amendment approved 2026-05-14
 - `ADR-014-class-hp-slot-count.md` — `hpSlotCount` parsed from CLASSES content at ingestion, stored as nullable `Integer` on `SrdItem`; approved 2026-05-14
 
-**Last updated:** 2026-05-14 — PBI-017–019 implemented and tested; all @frontend and @backend step definitions in place; increment on `increment/character-sheet-hp-domains-experience`, PR pending merge
+**Last updated:** 2026-05-15 — PBI-020, 021, 022 completed and passed independent review; UI consolidation increment on `increment/ui-consolidation`, PR #12 open for merge
 
 ---
 

--- a/dev-flow/design/PBI-020-nav-compendium-dropdown-design.md
+++ b/dev-flow/design/PBI-020-nav-compendium-dropdown-design.md
@@ -1,0 +1,175 @@
+# Design Specification — PBI-020: Navigation bar restructured into Compendium dropdown and Character Sheet top-level button
+
+**PBI:** PBI-020
+**Design Agent output date:** 2026-05-15
+**Status:** Draft
+
+---
+
+## 1. Feature Summary
+
+The navigation bar is split into two levels: a primary nav row with a "Compendium" toggle button and a "Character Sheet" button, and a secondary nav row containing all SRD category links. Both primary buttons carry the same diamond corner decoration currently used on SRD category buttons. The compendium secondary row opens and closes when the user clicks "Compendium", and its default state follows the active route.
+
+---
+
+## 2. Scope
+
+**IN scope for this design:**
+- Primary navigation row: "Compendium" button and "Character Sheet" button
+- Secondary navigation row: all SRD category links (moved from their current position in the header)
+- Diamond corner decorations on both primary buttons
+- Route-aware default open/closed state for the secondary row
+- Search bar position and appearance unchanged
+
+**OUT of scope:**
+- Animated transitions on the secondary row (show/hide only)
+- Changes to the SRD category list or TypeMenu button styling
+- Any change to the Character Sheet page
+
+---
+
+## 3. Pages and Routes Affected
+
+| Route | Page/Component | New or Modified |
+|---|---|---|
+| All routes | `App.tsx` (navigation area) | Modified |
+| All routes | `App.css` (nav styles) | Modified |
+| All routes | New `.app-nav-primary` and `.app-nav-secondary` nav rows | New |
+| `/` | Secondary row open by default | Modified behaviour |
+| `/:type/:filename` | Secondary row open by default | Modified behaviour |
+| `/character-sheet` | Secondary row collapsed by default | Modified behaviour |
+
+---
+
+## 4. Component Inventory
+
+| Component | Status | Location | Responsibility |
+|---|---|---|---|
+| `App.tsx` | Modified | `src/App.tsx` | Adds `isCompendiumOpen` state; renders two nav rows; derives default open state from route |
+| `App.css` | Modified | `src/App.css` | Adds styles for `.app-nav-primary`, `.app-nav-secondary`, `.app-nav__btn`, and diamond pseudo-elements |
+| `TypeMenu` | Modified | `src/components/TypeMenu.tsx` | Moves into the secondary nav row (rendered inside `.app-nav-secondary`); no internal changes needed |
+
+---
+
+## 5. Layout and Visual Structure
+
+### Navigation area — all routes
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  [Title/Logo]    [Search bar ........................]  [🌙]   │  ← existing app-header row (unchanged)
+├────────────────────────────────────────────────────────────────┤
+│  ◆ Compendium ◆       ◆ Character Sheet ◆                     │  ← primary nav row (.app-nav-primary)
+├────────────────────────────────────────────────────────────────┤
+│  [Ancestries] [Armor] [Classes] [Communities] [Items] [...]   │  ← secondary nav row (.app-nav-secondary)
+│                                   (visible when open)         │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**Primary nav row (`.app-nav-primary`):**
+- Contains exactly two buttons: "Compendium" and "Character Sheet"
+- Both use the same visual style as the current TypeMenu SRD category buttons: purple background, gold border, gold text
+- Both have the diamond `::before` and `::after` pseudo-element decoration (10×10px rotated squares, gold, positioned at top-left and bottom-right corners — identical pattern to `.type-menu button::before` / `::after`)
+- Row is full-width, flush below the app-header
+
+**Secondary nav row (`.app-nav-secondary`):**
+- Contains the TypeMenu buttons (all SRD categories)
+- Uses the same button styling as the current TypeMenu
+- Shown when `isCompendiumOpen` is `true`; hidden when `false`
+- Show/hide via CSS `display: none` / `display: flex` (no animation)
+
+**Sizing and spacing notes:**
+- Primary nav buttons: same padding, font-size, and border as current TypeMenu buttons
+- Both rows are full-width, same left/right padding as the app-header
+- Buttons in both rows wrap on small viewports (flex-wrap)
+
+**Responsive behaviour:**
+- Both rows use `flex-wrap: wrap` — buttons wrap naturally on narrow viewports
+
+---
+
+## 6. Interaction Specification
+
+### Toggle compendium secondary row
+
+**Trigger:** User clicks the "Compendium" button  
+**Precondition:** Any route; secondary row may be open or closed  
+**Outcome:** Secondary row visibility toggles (open → closed, closed → open)
+
+| State | Visual treatment |
+|---|---|
+| Secondary row open | "Compendium" button renders with an active/pressed background (slightly lighter or with `opacity: 0.85`) to indicate the row is expanded |
+| Secondary row closed | "Compendium" button renders in its standard state |
+
+### Navigate to Character Sheet
+
+**Trigger:** User clicks the "Character Sheet" button  
+**Precondition:** Any route  
+**Outcome:** React Router navigates to `/character-sheet`; secondary nav row collapses (if open)
+
+### Route-aware default state
+
+**Rule:** `isCompendiumOpen` is initialised based on the current route when the component mounts, and resets whenever the route changes:
+- Route is `/character-sheet` → secondary row closed
+- Any other route (including `/`, `/:type/:filename`, unknown routes) → secondary row open
+
+**Implementation note for Architecture Agent:** `useLocation()` from `react-router-dom` provides the pathname. A `useEffect` keyed on `pathname` sets `isCompendiumOpen` appropriately.
+
+### Click an SRD category in the secondary row
+
+**Trigger:** User clicks any TypeMenu button in the secondary row  
+**Precondition:** Secondary row is visible  
+**Outcome:** Existing TypeMenu behaviour (sets type filter, navigates) — unchanged
+
+---
+
+## 7. Copy and Labels
+
+| Element | Copy | Notes |
+|---|---|---|
+| Primary nav button 1 | "Compendium" | Title case; matches current header title |
+| Primary nav button 2 | "Character Sheet" | Title case; matches current link text |
+
+---
+
+## 8. Accessibility Notes
+
+- The "Compendium" button must have `aria-expanded` set to `"true"` or `"false"` based on secondary row visibility
+- The secondary nav row element should have `aria-hidden="true"` when collapsed
+- Both primary nav buttons are keyboard-focusable and activatable with Enter/Space (standard `<button>` behaviour)
+- Colour contrast: diamond decoration gold (`#d4b04f`) against purple button background meets WCAG AA for decorative elements; button text contrast already established by existing TypeMenu styles
+
+---
+
+## 9. Design Decisions and Rationale
+
+| Decision | Alternatives considered | Rationale |
+|---|---|---|
+| Primary nav buttons styled identically to TypeMenu buttons | Distinct "top-level" style (e.g., larger, different colour) | Visual consistency — using one button style throughout the nav avoids a two-tier visual hierarchy that would require additional design tokens and user orientation. |
+| Route-aware default: secondary row open on all non-character-sheet routes | Always collapsed on load; always open | Compendium is the primary use case. Opening it by default keeps category links discoverable without requiring an extra click on every visit. Character Sheet route collapses it to reduce visual noise. |
+| `display: none` show/hide, no animation | CSS `max-height` transition | The OUT scope explicitly excludes animated transitions. This keeps the implementation trivial and avoids layout-shift edge cases. |
+| Diamond decoration reuses existing `::before` / `::after` pattern from `.type-menu button` | New shared CSS class | Reusing the identical pattern is zero-risk and requires no refactoring of existing styles. |
+| `isCompendiumOpen` state lives in `App.tsx` | Dedicated NavBar component; React Context | The state is local to the nav area. No other component needs it. Keeping it in `App.tsx` avoids unnecessary component extraction. |
+
+---
+
+## 10. Open Design Questions
+
+No open design questions.
+
+---
+
+## 11. Scenario Traceability
+
+| Scenario | Addressed by |
+|---|---|
+| Primary navigation row contains Compendium and Character Sheet buttons | Section 5 — Primary nav row layout |
+| Landing on the homepage shows the compendium secondary row open by default | Section 6 — Route-aware default state |
+| Clicking Compendium collapses the secondary row when it is open | Section 6 — Toggle interaction |
+| Clicking Compendium expands the secondary row when it is collapsed | Section 6 — Toggle interaction |
+| Clicking Character Sheet navigates to the character sheet page | Section 6 — Navigate to Character Sheet |
+| Navigating to the character sheet collapses the secondary navigation row | Section 6 — Route-aware default state |
+| Navigating directly to a compendium item page shows the secondary row open | Section 6 — Route-aware default state |
+| Compendium button has diamond corner decorations | Section 5 — Primary nav row; Section 9 — Diamond decoration decision |
+| Character Sheet button has diamond corner decorations | Section 5 — Primary nav row; Section 9 — Diamond decoration decision |
+| Search bar remains present and usable after navigation restructure | Section 2 — Scope (search bar unchanged); Section 5 — app-header row unchanged |

--- a/dev-flow/design/PBI-021-character-sheet-identity-traits-layout-design.md
+++ b/dev-flow/design/PBI-021-character-sheet-identity-traits-layout-design.md
@@ -1,0 +1,148 @@
+# Design Specification — PBI-021: Character sheet identity row full-width and traits 2-column layout
+
+**PBI:** PBI-021
+**Design Agent output date:** 2026-05-15
+**Status:** Draft (revised — traits internal layout updated to 6-column single row)
+
+---
+
+## 1. Feature Summary
+
+The character sheet is restructured so that the identity fields (Name, Pronouns, Class, Subclass, Heritage, Level) appear as a single full-width row spanning both columns, and the trait scores section appears as a full-width row immediately below it. All other sections remain in the existing two-column layout beneath the traits row.
+
+---
+
+## 2. Scope
+
+**IN scope for this design:**
+- `ClassHeader` component moved out of the left column and into its own full-width row above the column grid
+- `TraitsSection` component moved out of the left column and into a full-width row between the identity row and the column grid
+- All remaining sections (`DefenceSection`, `DamageHealthSection`, `HopeSection`, `ExperienceSection`, `GoldSection`, `ActiveWeaponsSection`, `ActiveArmorSection`, `InventorySection`) remain in the existing two-column grid unchanged
+- `ClassFeatureSection` remains below the grid (full-width, unchanged)
+
+**OUT of scope:**
+- Changes to which fields appear in the identity or traits sections
+- Changes to character state or data
+- Changes to any section other than layout positioning of ClassHeader and TraitsSection
+
+---
+
+## 3. Pages and Routes Affected
+
+| Route | Page/Component | New or Modified |
+|---|---|---|
+| `/character-sheet` | `CharacterSheetPage.tsx` | Modified — layout restructured |
+| `/character-sheet` | `App.css` | Modified — new layout rules for identity and traits rows |
+
+---
+
+## 4. Component Inventory
+
+| Component | Status | Location | Responsibility |
+|---|---|---|---|
+| `CharacterSheetPage.tsx` | Modified | `src/features/character-sheet/components/CharacterSheetPage.tsx` | Moves `ClassHeader` and `TraitsSection` to full-width rows above the column grid |
+| `App.css` | Modified | `src/App.css` | Adds full-width layout rules for the identity and traits rows within the character sheet |
+| `ClassHeader.tsx` | No change | `src/features/character-sheet/components/ClassHeader.tsx` | Component internals unchanged |
+| `TraitsSection.tsx` | Modified | `src/features/character-sheet/components/TraitsSection.tsx` | Internal grid changed from `repeat(3, 1fr)` to `repeat(6, 1fr)` — all 6 traits displayed in a single inline row |
+
+---
+
+## 5. Layout and Visual Structure
+
+### Character Sheet page
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  Character Sheet                               (page title)         │
+├────────────────────────────────────────────────────────────────────┤
+│  Name: [___________]  Pronouns: [______]  Class: [________▾]       │  ← full-width (.character-sheet__identity-row)
+│  Subclass: [_______▾] Heritage: [______▾] Level: [__]              │    ClassHeader spans both columns
+├────────────────────────────────────────────────────────────────────┤
+│  Agility│Strength│Finesse│Instinct│Presence│Knowledge              │  ← full-width (.character-sheet__traits-row)
+│  [___] │ [___]  │ [___] │ [___]  │ [___]  │ [___]                 │    all 6 trait columns side by side
+│  Sprint │ Lift   │Control│Perceive│ Charm  │Recall                 │    repeat(6, 1fr) internal grid
+│  Leap   │ Smash  │ Hide  │ Sense  │Perform │Analyze                │
+│  Maneuvr│ Grapple│Tinker │Navigate│Deceive │Comprehend             │
+├──────────────────────────────┬─────────────────────────────────────┤
+│  LEFT COLUMN                 │  RIGHT COLUMN                        │  ← existing .character-sheet__columns grid
+│  DefenceSection              │  ActiveWeaponsSection               │    (unchanged)
+│  DamageHealthSection         │  ActiveArmorSection                 │
+│  HopeSection                 │  InventorySection                   │
+│  ExperienceSection           │                                     │
+│  GoldSection                 │                                     │
+├────────────────────────────────────────────────────────────────────┤
+│  ClassFeatureSection                                                │  ← full-width (unchanged)
+└────────────────────────────────────────────────────────────────────┘
+```
+
+**Identity row (`.character-sheet__identity-row`):**
+- Full-width wrapper outside of `.character-sheet__columns`
+- Renders `<ClassHeader />` directly
+- `ClassHeader`'s internal `.class-header__identity` grid (`1fr 1fr`, 6 fields in 2 columns) is unchanged — it now simply has more available horizontal space
+- Section card styling (`.character-sheet__section`) applies to `ClassHeader` as before
+
+**Traits row (`.character-sheet__traits-row`):**
+- Full-width wrapper outside of `.character-sheet__columns`
+- Renders `<TraitsSection />` directly
+- `TraitsSection`'s internal `.traits-section__columns` grid changes from `repeat(3, 1fr)` to `repeat(6, 1fr)` — all 6 trait columns sit side by side in a single row
+- Section card styling applies as before
+
+**Column grid (`.character-sheet__columns`):**
+- Unchanged: `grid-template-columns: 1fr 1fr`, same sections as before minus `ClassHeader` and `TraitsSection`
+
+**Sizing and spacing notes:**
+- `.character-sheet__identity-row` and `.character-sheet__traits-row` have the same `margin-bottom: 1rem` as section cards to maintain vertical rhythm
+- No change to max-width or padding of the `.character-sheet` container
+
+**Responsive behaviour:**
+- At ≤768px (single-column breakpoint), the identity row and traits row already render full-width — no additional responsive change needed
+- `TraitsSection`'s internal grid should collapse from `repeat(6, 1fr)` to `repeat(3, 1fr)` at ≤768px (matching the previous desktop layout), and to `repeat(2, 1fr)` at ≤480px if needed. The exact breakpoints are an implementation detail for the Architecture/Implementation Agent to confirm.
+
+---
+
+## 6. Interaction Specification
+
+No new interactions. All fields remain editable as before. Focus management unchanged.
+
+---
+
+## 7. Copy and Labels
+
+No copy changes. All field labels remain identical.
+
+---
+
+## 8. Accessibility Notes
+
+- No changes to heading hierarchy (each section retains its `<h2>`)
+- Reading order in the DOM should match the visual order: identity row first, traits row second, columns grid third — `CharacterSheetPage.tsx` must render them in this order
+- No new ARIA requirements introduced
+
+---
+
+## 9. Design Decisions and Rationale
+
+| Decision | Alternatives considered | Rationale |
+|---|---|---|
+| `TraitsSection` internal grid changed to `repeat(6, 1fr)` | Keep `repeat(3, 1fr)` in wider space; use `repeat(2, 1fr)` | The user explicitly requested all 6 traits displayed inline (side by side). `repeat(6, 1fr)` achieves this. The full-width row gives sufficient horizontal space for 6 reasonably-sized columns on desktop. |
+| `ClassHeader` and `TraitsSection` placed in wrapper divs above the column grid | `grid-column: 1 / -1` inside the column grid | Wrapper divs outside the grid are cleaner than spanning grid items, which can interfere with the `align-items: start` rule on the column grid. |
+| `ClassHeader` internal layout unchanged (2-col `class-header__identity` grid) | Expand to 3-col or single row | The 6 fields in 2 columns is already readable and compact. The user did not request a change to the identity fields themselves — only to their position on the page. |
+
+---
+
+## 10. Open Design Questions
+
+No open design questions.
+
+---
+
+## 11. Scenario Traceability
+
+| Scenario | Addressed by |
+|---|---|
+| Identity row spans the full width of the character sheet | Section 5 — Identity row layout |
+| Trait scores section is displayed in a 2-column layout below the identity row | Section 5 — Traits row layout; Section 9 — TraitsSection spans both page columns |
+| Identity row is displayed above the traits section | Section 5 — DOM order (identity row → traits row → column grid) |
+| Sections below the traits block remain in the existing 2-column layout | Section 5 — Column grid unchanged |
+| Identity fields remain editable after layout change | Section 6 — No interaction changes; ClassHeader internals unchanged |
+| Trait score inputs remain editable after layout change | Section 6 — No interaction changes; TraitsSection internals unchanged |

--- a/dev-flow/design/PBI-022-damage-thresholds-inline-design.md
+++ b/dev-flow/design/PBI-022-damage-thresholds-inline-design.md
@@ -1,0 +1,189 @@
+# Design Specification — PBI-022: Damage thresholds as inline 2-input row in Damage and Health section
+
+**PBI:** PBI-022
+**Design Agent output date:** 2026-05-15
+**Status:** Draft
+
+---
+
+## 1. Feature Summary
+
+The three stacked damage threshold rows (Minor, Major, Severe — each with its own label and input) are replaced by a single inline row that reads: "Minor Damage | [input] | Major Damage | [input] | Severe Damage". Exactly two number inputs are present: one for the Minor-to-Major boundary and one for the Major-to-Severe boundary. Character state is reduced from three threshold fields to two.
+
+---
+
+## 2. Scope
+
+**IN scope for this design:**
+- Replacement of the three stacked `.damage-health-section__threshold-row` rows with one inline threshold row
+- Inline layout: label → input → label → input → label
+- Exactly two number inputs, independently editable
+- Character state `damageThresholds` reduced from `{ minor, major, severe }` to `{ minor, major }`
+- Hint text "Add your current level" retained above the inline row
+
+**OUT of scope:**
+- Changes to HP slots, stress slots, hope, gold, or any other part of the Damage & Health section
+- Changes to any other character sheet section
+
+---
+
+## 3. Pages and Routes Affected
+
+| Route | Page/Component | New or Modified |
+|---|---|---|
+| `/character-sheet` | `DamageHealthSection.tsx` | Modified — threshold rendering replaced |
+| `/character-sheet` | `App.css` | Modified — new inline threshold row styles |
+| `/character-sheet` | `CharacterContext.tsx` | Modified — `damageThresholds` state shape updated |
+| `/character-sheet` | `character.ts` (types) | Modified — `DamageThresholds` type updated |
+| `/character-sheet` | `useCharacterHealth.ts` | Modified — `setDamageThreshold` updated for two fields |
+
+---
+
+## 4. Component Inventory
+
+| Component | Status | Location | Responsibility |
+|---|---|---|---|
+| `DamageHealthSection.tsx` | Modified | `src/features/character-sheet/components/DamageHealthSection.tsx` | Renders the new inline threshold row instead of three stacked rows |
+| `App.css` | Modified | `src/App.css` | Adds `.damage-health-section__thresholds-inline` layout styles |
+| `CharacterContext.tsx` | Modified | `src/features/character-sheet/context/CharacterContext.tsx` | Updates `damageThresholds` initial state and reducer to use `{ minor, major }` |
+| `character.ts` | Modified | `src/features/character-sheet/types/character.ts` | Updates `DamageThresholds` type to `{ minor: number \| null; major: number \| null }` |
+| `useCharacterHealth.ts` | Modified | `src/features/character-sheet/hooks/useCharacterHealth.ts` | Removes `severe` threshold from return value |
+
+---
+
+## 5. Layout and Visual Structure
+
+### Damage & Health section — threshold area
+
+**Before (current):**
+```
+┌──────────────────────────────────────────┐
+│  Damage & Health                         │
+│  Add your current level                  │
+│                                          │
+│  Minor Damage     [ 5 ]                  │
+│  Major Damage     [ 12]                  │
+│  Severe Damage    [ 20]                  │
+│                                          │
+│  HP   ■ ■ ■ □ □ □ □ □ □ □              │
+│  ...                                     │
+└──────────────────────────────────────────┘
+```
+
+**After (new):**
+```
+┌──────────────────────────────────────────┐
+│  Damage & Health                         │
+│  Add your current level                  │
+│                                          │
+│  Minor Damage  [ 5 ]  Major Damage  [12]  Severe Damage  │
+│                                          │
+│  HP   ■ ■ ■ □ □ □ □ □ □ □              │
+│  ...                                     │
+└──────────────────────────────────────────┘
+```
+
+**Inline row layout (`.damage-health-section__thresholds-inline`):**
+- `display: flex`
+- `flex-direction: row`
+- `align-items: center`
+- `flex-wrap: wrap`
+- `gap: 0.5rem`
+- Children: `<span>` labels alternating with `<input>` fields
+
+**Element order in DOM:**
+1. `<span>Minor Damage</span>`
+2. `<input type="number" />` — Minor-to-Major threshold (id: `threshold-minor`)
+3. `<span>Major Damage</span>`
+4. `<input type="number" />` — Major-to-Severe threshold (id: `threshold-major`)
+5. `<span>Severe Damage</span>`
+
+**Input sizing:**
+- Width: `4rem` (same as current `.damage-health-section__threshold-input`)
+- `text-align: center`
+- `type="number"` with `min={0}`
+
+**Label styling:**
+- Reuse `.damage-health-section__threshold-label` (existing class) on the `<span>` elements
+- No change to font, colour, or size
+
+**Hint text:**
+- The existing `<p className="damage-health-section__hint">Add your current level</p>` is retained above the inline row, unchanged
+
+**Sizing and spacing notes:**
+- The inline row replaces exactly the space previously occupied by the three stacked rows — overall section height reduces since three rows become one
+- `flex-wrap: wrap` ensures the row wraps gracefully if the section width is narrow (e.g., on mobile)
+
+**Responsive behaviour:**
+- On narrow viewports the inline row wraps; the three labels and two inputs remain readable as a wrapped sequence
+
+---
+
+## 6. Interaction Specification
+
+### Edit the Minor-to-Major threshold
+
+**Trigger:** User clicks the first input and types a number  
+**Precondition:** Character sheet is displayed  
+**Outcome:** `damageThresholds.minor` in character state is updated; input displays the typed value
+
+### Edit the Major-to-Severe threshold
+
+**Trigger:** User clicks the second input and types a number  
+**Precondition:** Character sheet is displayed  
+**Outcome:** `damageThresholds.major` in character state is updated; input displays the typed value
+
+| State | Visual treatment |
+|---|---|
+| Default (empty) | Input displays blank or `0` per existing behaviour |
+| Focused | Browser default focus ring |
+| Filled | Number displays in centred input |
+
+---
+
+## 7. Copy and Labels
+
+| Element | Copy | Notes |
+|---|---|---|
+| Label 1 | "Minor Damage" | Static `<span>` |
+| Label 2 | "Major Damage" | Static `<span>` |
+| Label 3 | "Severe Damage" | Static `<span>` |
+| Hint text | "Add your current level" | Unchanged from current |
+
+---
+
+## 8. Accessibility Notes
+
+- Each input needs an accessible label. Because the inputs sit inline between text labels, use `aria-label` on each input: first input `aria-label="Minor to Major damage threshold"`, second input `aria-label="Major to Severe damage threshold"`
+- The `<span>` labels are decorative in the accessibility tree — no `for` attribute binding needed given the `aria-label` on the inputs
+- Keyboard navigation: Tab moves between the two inputs in DOM order; standard number input behaviour applies
+
+---
+
+## 9. Design Decisions and Rationale
+
+| Decision | Alternatives considered | Rationale |
+|---|---|---|
+| Remove `severe` from `DamageThresholds` state | Keep `severe` and just hide its input | The "Severe Damage" label at the end of the row is purely descriptive — it is the category with no upper bound. Storing a `severe` threshold value that is never displayed or edited is dead state. Removing it keeps the data model honest. |
+| Retain existing input width (4rem) | Wider input for better usability | The inputs hold short numeric values (typically 1–30). 4rem is sufficient. Widening would break the compact inline layout. |
+| Labels as `<span>` elements | `<label>` elements with `htmlFor` | Using `<label htmlFor>` for inline text between inputs creates confusing click targets (clicking the label focuses the associated input, which is unintuitive mid-sentence). `<span>` with `aria-label` on inputs is the correct accessible pattern for this layout. |
+| `flex-wrap: wrap` on the inline row | Fixed single line (no wrap) | Prevents the row from overflowing the section at narrow widths without needing a horizontal scrollbar. |
+
+---
+
+## 10. Open Design Questions
+
+No open design questions.
+
+---
+
+## 11. Scenario Traceability
+
+| Scenario | Addressed by |
+|---|---|
+| Damage threshold row displays labels and inputs in the correct inline order | Section 5 — Inline row layout, element order |
+| Damage threshold section contains exactly two input fields | Section 5 — Exactly two `<input>` elements |
+| User can enter a value for the Minor-to-Major threshold | Section 6 — Edit Minor-to-Major threshold interaction |
+| User can enter a value for the Major-to-Severe threshold | Section 6 — Edit Major-to-Severe threshold interaction |
+| Threshold values are retained while interacting with other sheet fields | Section 5 — state managed in CharacterContext (no re-render resets) |
+| Both threshold inputs are independently editable | Section 5 — Two separate inputs bound to separate state fields |

--- a/dev-flow/engineering/architecture/PBI-020-nav-compendium-dropdown-flow.md
+++ b/dev-flow/engineering/architecture/PBI-020-nav-compendium-dropdown-flow.md
@@ -1,0 +1,70 @@
+# Flow Descriptor — PBI-020: Navigation bar restructured into Compendium dropdown and Character Sheet top-level button
+
+**PBI:** PBI-020
+**ADR required:** No — this change uses only existing patterns: React local state (`useState`), React Router's `useLocation`, conditional rendering, and CSS `::before`/`::after` pseudo-elements already established in `.type-menu button`. No new dependencies, no new data model, no API changes.
+
+---
+
+## 1. What This Builds
+
+Restructures the navigation area in `App.tsx` into two rows. The primary row holds a "Compendium" toggle button and a "Character Sheet" link button, both styled and decorated identically to the existing TypeMenu SRD category buttons. The secondary row holds the TypeMenu (all SRD category links), shown or hidden based on `isCompendiumOpen` state. The open/closed default follows the active route: open on all routes except `/character-sheet`.
+
+Acceptance scenarios covered: all 10 scenarios in `PBI-020-nav-compendium-dropdown.feature`.
+
+---
+
+## 2. Component Map
+
+| Component | Change | Notes |
+|---|---|---|
+| `App.tsx` | Modified | Adds `isCompendiumOpen` state; adds `useLocation` effect to set default; renders `.app-nav-primary` and `.app-nav-secondary` rows |
+| `App.css` | Modified | Adds styles for `.app-nav-primary`, `.app-nav-secondary`, `.app-nav__btn`; adds diamond `::before`/`::after` decoration on `.app-nav__btn` |
+| `TypeMenu.tsx` | No change | Moved into `.app-nav-secondary` wrapper in `App.tsx`; component internals unchanged |
+
+No new components. No backend changes.
+
+---
+
+## 3. Data Flow
+
+```mermaid
+flowchart TD
+    A[App mounts / route changes] -->|useLocation pathname| B{pathname === '/character-sheet'?}
+    B -->|yes| C[setIsCompendiumOpen(false)]
+    B -->|no| D[setIsCompendiumOpen(true)]
+
+    E[User clicks Compendium button] --> F[setIsCompendiumOpen(prev => !prev)]
+
+    G[User clicks Character Sheet button] --> H[React Router navigates to /character-sheet]
+    H --> B
+
+    C --> I[Secondary nav row hidden]
+    D --> J[Secondary nav row visible]
+    F --> K[Secondary nav row toggles]
+```
+
+**State location:** `isCompendiumOpen: boolean` — local state in `App.tsx` via `useState`.
+
+**Route sync:** A `useEffect` keyed on `location.pathname` sets `isCompendiumOpen` to `false` when pathname is `/character-sheet`, `true` otherwise.
+
+---
+
+## 4. API Contract
+
+No API changes. This is a purely frontend layout and state change.
+
+---
+
+## 5. Security Notes
+
+No security implications. This change affects only navigation layout and a client-side open/closed toggle. No user input is collected, no data is persisted, no auth state is involved. The TypeMenu buttons' existing behaviour (type filtering, navigation) is unchanged.
+
+---
+
+## 6. Consistency Notes
+
+- **Local state pattern:** `useState` for `isCompendiumOpen` follows the same local state pattern used throughout `App.tsx` (e.g., `darkMode`, `searchQuery`, `selectedType`). No deviation.
+- **Route-aware effect:** `useEffect` keyed on `useLocation().pathname` follows the React Router pattern already used in the codebase. No new pattern.
+- **Diamond decoration:** Reuses the identical `::before`/`::after` CSS pseudo-element pattern from `.type-menu button` (lines 86–104 of `App.css`). No new CSS pattern.
+- **Button style:** `.app-nav__btn` uses the same colour tokens (`#4a2a99` background, `#ffd166` text, `#d4b04f` border) as the existing `.type-menu button` and `.app-nav__link` styles. No new design tokens.
+- Follows ADR-011 (React Router URL Navigation) — navigation remains BrowserRouter-based.

--- a/dev-flow/engineering/architecture/PBI-021-character-sheet-identity-traits-layout-flow.md
+++ b/dev-flow/engineering/architecture/PBI-021-character-sheet-identity-traits-layout-flow.md
@@ -1,0 +1,63 @@
+# Flow Descriptor — PBI-021: Character sheet identity row full-width and traits 6-column inline layout
+
+**PBI:** PBI-021
+**ADR required:** No — pure layout restructure. No state changes, no new components, no API changes, no new patterns. Follows the existing full-width section pattern already established by `ClassFeatureSection` in `CharacterSheetPage.tsx`.
+
+---
+
+## 1. What This Builds
+
+Moves `ClassHeader` and `TraitsSection` out of the left column in `CharacterSheetPage.tsx` and places them as full-width rows above the two-column grid. `TraitsSection`'s internal CSS grid is updated from `repeat(3, 1fr)` to `repeat(6, 1fr)` so all six traits display side by side in a single row. Everything below (DefenceSection, DamageHealthSection, HopeSection, ExperienceSection, GoldSection, ActiveWeaponsSection, ActiveArmorSection, InventorySection) remains in the unchanged two-column grid. `ClassFeatureSection` remains full-width below the grid as before.
+
+Acceptance scenarios covered: all 6 scenarios in `PBI-021-character-sheet-identity-traits-layout.feature`.
+
+---
+
+## 2. Component Map
+
+| Component | Change | Notes |
+|---|---|---|
+| `CharacterSheetPage.tsx` | Modified | Removes `ClassHeader` and `TraitsSection` from left column; renders them in wrapper divs above `.character-sheet__columns` |
+| `TraitsSection.tsx` | Modified | CSS class `.traits-section__columns` grid updated from `repeat(3, 1fr)` to `repeat(6, 1fr)`; responsive breakpoint added to collapse to `repeat(3, 1fr)` at ≤768px |
+| `App.css` | Modified | Adds `.character-sheet__identity-row` and `.character-sheet__traits-row` wrapper styles; updates `.traits-section__columns` grid |
+| `ClassHeader.tsx` | No change | Component internals unchanged |
+
+No new components. No backend changes. No state changes.
+
+---
+
+## 3. Data Flow
+
+No data flow changes. All hooks (`useCharacterIdentity`, `useCharacterTraits`) remain unchanged. The only change is DOM structure and CSS layout.
+
+```
+CharacterSheetPage
+├── .character-sheet__identity-row  [NEW wrapper — full-width]
+│   └── <ClassHeader />              [moved from left column]
+├── .character-sheet__traits-row    [NEW wrapper — full-width]
+│   └── <TraitsSection />            [moved from left column; internal grid updated]
+├── .character-sheet__columns       [unchanged 2-col grid]
+│   ├── left: DefenceSection, DamageHealthSection, HopeSection, ExperienceSection, GoldSection
+│   └── right: ActiveWeaponsSection, ActiveArmorSection, InventorySection
+└── <ClassFeatureSection />          [unchanged full-width below grid]
+```
+
+---
+
+## 4. API Contract
+
+No API changes.
+
+---
+
+## 5. Security Notes
+
+No security implications. This is a layout-only change. No user input handling changes. No data persistence involved.
+
+---
+
+## 6. Consistency Notes
+
+- **Full-width section pattern:** Moving components outside `.character-sheet__columns` and rendering them as full-width rows is the same pattern used for `ClassFeatureSection` (PBI-016). No deviation from established practice.
+- **CSS grid update:** Changing `.traits-section__columns` from `repeat(3, 1fr)` to `repeat(6, 1fr)` is a straightforward CSS property change. Responsive collapse to `repeat(3, 1fr)` at ≤768px preserves usability on narrow viewports and mirrors the existing responsive pattern in `.character-sheet__columns`.
+- Follows ADR-012 (Character Sheet State Management) — no state structure changes.

--- a/dev-flow/engineering/architecture/PBI-022-damage-thresholds-inline-flow.md
+++ b/dev-flow/engineering/architecture/PBI-022-damage-thresholds-inline-flow.md
@@ -1,0 +1,71 @@
+# Flow Descriptor — PBI-022: Damage thresholds as inline 2-input row in Damage and Health section
+
+**PBI:** PBI-022
+**ADR required:** No — the `DamageThresholds` type is local frontend state within the character-sheet feature (not persisted, not shared via API, not a database schema). Reducing it from three fields to two is a contained state shape change within the existing ADR-012 (Character Sheet State Management) context. No new patterns, no new dependencies, no API changes.
+
+---
+
+## 1. What This Builds
+
+Replaces the three stacked damage threshold rows in `DamageHealthSection` with a single inline row: `Minor Damage → [input] → Major Damage → [input] → Severe Damage`. The `severe` field is removed from the `DamageThresholds` type and all associated state, reducer, and hook code. The component renders the inline row with two number inputs and three static label spans, styled to sit on one line with flex layout.
+
+Acceptance scenarios covered: all 6 scenarios in `PBI-022-damage-thresholds-inline.feature`.
+
+---
+
+## 2. Component Map
+
+| Component | Change | Notes |
+|---|---|---|
+| `DamageHealthSection.tsx` | Modified | Replaces three `threshold-row` divs with a single `.damage-health-section__thresholds-inline` flex row |
+| `character.ts` | Modified | `DamageThresholds` type: removes `severe` field → `{ minor: number \| null; major: number \| null }` |
+| `CharacterContext.tsx` | Modified | Initial state removes `severe`; `SET_DAMAGE_THRESHOLD` reducer removes `severe` case |
+| `useCharacterHealth.ts` | Modified | Removes `damageThresholds.severe` from returned value |
+| `App.css` | Modified | Adds `.damage-health-section__thresholds-inline` flex row styles |
+
+No new components. No backend changes.
+
+---
+
+## 3. Data Flow
+
+```mermaid
+flowchart TD
+    A[User types in first threshold input] -->|onChange| B[dispatch SET_DAMAGE_THRESHOLD minor = value]
+    C[User types in second threshold input] -->|onChange| D[dispatch SET_DAMAGE_THRESHOLD major = value]
+
+    B --> E[CharacterContext reducer updates state.damageThresholds.minor]
+    D --> F[CharacterContext reducer updates state.damageThresholds.major]
+
+    E --> G[useCharacterHealth returns updated damageThresholds]
+    F --> G
+    G --> H[DamageHealthSection re-renders with new input values]
+```
+
+**State shape change:**
+
+Before: `damageThresholds: { minor: number | null; major: number | null; severe: number | null }`  
+After: `damageThresholds: { minor: number | null; major: number | null }`
+
+The `severe` field is removed entirely. No migration is required since the character sheet state is ephemeral (not persisted to backend or localStorage).
+
+---
+
+## 4. API Contract
+
+No API changes. Character sheet state is entirely client-side.
+
+---
+
+## 5. Security Notes
+
+No security implications. The two inputs accept `type="number"` values only. No data crosses a trust boundary — the values are never sent to the backend. `aria-label` attributes are required on both inputs per the design spec (accessibility, not security).
+
+---
+
+## 6. Consistency Notes
+
+- **State update pattern:** `dispatch(SET_DAMAGE_THRESHOLD, { field, value })` follows the same action dispatch pattern used for all other character sheet state mutations in `CharacterContext.tsx`. No deviation from ADR-012.
+- **Inline flex row:** The `.damage-health-section__thresholds-inline` layout (flex row, align-items center, gap 0.5rem) is a straightforward CSS addition. No new layout pattern.
+- **Removing a state field:** Dropping `severe` from `DamageThresholds` is the correct approach — storing a value that is never displayed or edited is dead state. Since the character sheet has no persistence layer, there is no migration risk.
+- Follows ADR-012 (Character Sheet State Management) — reducer and dispatch pattern unchanged; only the state shape shrinks.

--- a/dev-flow/product/PBI-020-nav-compendium-dropdown.feature
+++ b/dev-flow/product/PBI-020-nav-compendium-dropdown.feature
@@ -1,0 +1,68 @@
+Feature: Navigation bar restructured into Compendium dropdown and Character Sheet top-level button
+  As a user, I want to navigate to either the SRD compendium or the character sheet
+  from a clear top-level navigation bar, so I can reach my destination in one click
+  without scanning through a flat list of category links.
+  Backlog item: PBI-020
+
+  Background:
+    Given the application is running
+
+  @smoke @frontend
+  Scenario: Primary navigation row contains Compendium and Character Sheet buttons
+    When the user views any page
+    Then the primary navigation row contains a "Compendium" button
+    And the primary navigation row contains a "Character Sheet" button
+    And the primary navigation row does not contain individual SRD category links
+
+  @smoke @frontend
+  Scenario: Landing on the homepage shows the compendium secondary row open by default
+    When the user navigates to the homepage
+    Then the secondary navigation row is visible
+    And the secondary navigation row contains links for all SRD categories
+
+  @regression @frontend
+  Scenario: Clicking Compendium collapses the secondary row when it is open
+    Given the user is on the homepage
+    And the secondary navigation row is visible
+    When they click the "Compendium" button
+    Then the secondary navigation row is hidden
+
+  @regression @frontend
+  Scenario: Clicking Compendium expands the secondary row when it is collapsed
+    Given the user is on the homepage
+    And the secondary navigation row is hidden
+    When they click the "Compendium" button
+    Then the secondary navigation row is visible
+
+  @regression @frontend
+  Scenario: Clicking Character Sheet navigates to the character sheet page
+    Given the user is on the homepage
+    When they click the "Character Sheet" button
+    Then the character sheet page is displayed
+
+  @regression @frontend
+  Scenario: Navigating to the character sheet collapses the secondary navigation row
+    Given the user is on the homepage
+    And the secondary navigation row is visible
+    When they click the "Character Sheet" button
+    Then the secondary navigation row is hidden
+
+  @regression @frontend
+  Scenario: Navigating directly to a compendium item page shows the secondary row open
+    When the user navigates directly to a compendium item page
+    Then the secondary navigation row is visible
+
+  @regression @frontend
+  Scenario: Compendium button has diamond corner decorations
+    When the user views the primary navigation row
+    Then the "Compendium" button has the diamond corner decoration style
+
+  @regression @frontend
+  Scenario: Character Sheet button has diamond corner decorations
+    When the user views the primary navigation row
+    Then the "Character Sheet" button has the diamond corner decoration style
+
+  @regression @frontend
+  Scenario: Search bar remains present and usable after navigation restructure
+    When the user views the homepage
+    Then the search bar is visible in the navigation area

--- a/dev-flow/product/PBI-021-character-sheet-identity-traits-layout.feature
+++ b/dev-flow/product/PBI-021-character-sheet-identity-traits-layout.feature
@@ -1,0 +1,36 @@
+Feature: Character sheet identity row full-width and traits 2-column layout
+  As a character sheet user, I want the identity fields to span the full width at the
+  top of the sheet and the trait scores to sit in a 2-column layout immediately below,
+  so the sheet has a clear visual hierarchy with identity prominent and traits compact.
+  Backlog item: PBI-021
+
+  Background:
+    Given the application is running
+    And the user is on the character sheet page
+
+  @smoke @frontend
+  Scenario: Identity row spans the full width of the character sheet
+    Then the identity row containing the Name, Pronouns, and Class fields spans the full width of the sheet
+
+  @smoke @frontend
+  Scenario: Trait scores section is displayed in a 2-column layout
+    Then the traits section is displayed in a 2-column layout below the identity row
+
+  @regression @frontend
+  Scenario: Identity row is displayed above the traits section
+    Then the identity row appears above the traits section on the character sheet
+
+  @regression @frontend
+  Scenario: Sections below the traits block remain in the existing 2-column layout
+    Then the Damage and Health section appears below the traits section
+    And it is displayed in the 2-column layout
+
+  @regression @frontend
+  Scenario: Identity fields remain editable after layout change
+    When the user enters "Aria" in the Name field
+    Then the Name field displays "Aria"
+
+  @regression @frontend
+  Scenario: Trait score inputs remain editable after layout change
+    When the user enters "3" in the Agility trait input
+    Then the Agility trait input displays "3"

--- a/dev-flow/product/PBI-021-character-sheet-identity-traits-layout.feature
+++ b/dev-flow/product/PBI-021-character-sheet-identity-traits-layout.feature
@@ -1,7 +1,7 @@
-Feature: Character sheet identity row full-width and traits 2-column layout
+Feature: Character sheet identity row full-width and traits inline 6-column layout
   As a character sheet user, I want the identity fields to span the full width at the
-  top of the sheet and the trait scores to sit in a 2-column layout immediately below,
-  so the sheet has a clear visual hierarchy with identity prominent and traits compact.
+  top of the sheet and the trait scores to sit in a single inline row immediately below,
+  so the sheet has a clear visual hierarchy with identity prominent and all six traits visible at a glance.
   Backlog item: PBI-021
 
   Background:
@@ -13,8 +13,8 @@ Feature: Character sheet identity row full-width and traits 2-column layout
     Then the identity row containing the Name, Pronouns, and Class fields spans the full width of the sheet
 
   @smoke @frontend
-  Scenario: Trait scores section is displayed in a 2-column layout
-    Then the traits section is displayed in a 2-column layout below the identity row
+  Scenario: Trait scores section is displayed as a full-width inline row below the identity row
+    Then the traits section is displayed as a full-width inline row below the identity row
 
   @regression @frontend
   Scenario: Identity row is displayed above the traits section

--- a/dev-flow/product/PBI-022-damage-thresholds-inline.feature
+++ b/dev-flow/product/PBI-022-damage-thresholds-inline.feature
@@ -1,0 +1,44 @@
+Feature: Damage thresholds displayed as inline 2-input row in Damage and Health section
+  As a character sheet user, I want the damage thresholds shown as a single inline row
+  "Minor Damage | [input] | Major Damage | [input] | Severe Damage" with exactly two
+  input fields, so I can see and set the category boundaries at a glance.
+  Backlog item: PBI-022
+
+  Background:
+    Given the application is running
+    And the user is on the character sheet page
+
+  @smoke @frontend
+  Scenario: Damage threshold row displays labels and inputs in the correct inline order
+    Then the damage threshold row displays "Minor Damage" followed by an input field
+    And then "Major Damage" followed by an input field
+    And then "Severe Damage" as a trailing label
+
+  @smoke @frontend
+  Scenario: Damage threshold section contains exactly two input fields
+    Then the damage threshold section contains exactly 2 input fields
+
+  @regression @frontend
+  Scenario: User can enter a value for the Minor-to-Major threshold
+    When the user enters "5" in the first damage threshold input
+    Then the first damage threshold input displays "5"
+
+  @regression @frontend
+  Scenario: User can enter a value for the Major-to-Severe threshold
+    When the user enters "12" in the second damage threshold input
+    Then the second damage threshold input displays "12"
+
+  @regression @frontend
+  Scenario: Threshold values are retained while interacting with other sheet fields
+    When the user enters "5" in the first damage threshold input
+    And the user enters "12" in the second damage threshold input
+    And the user enters "Aria" in the Name field
+    Then the first damage threshold input still displays "5"
+    And the second damage threshold input still displays "12"
+
+  @regression @frontend
+  Scenario: Both threshold inputs are independently editable
+    When the user enters "4" in the first damage threshold input
+    And the user enters "11" in the second damage threshold input
+    Then the first damage threshold input displays "4"
+    And the second damage threshold input displays "11"

--- a/frontend/e2e/pages/AppPage.ts
+++ b/frontend/e2e/pages/AppPage.ts
@@ -821,12 +821,23 @@ export class AppPage {
 
     async clickPrimaryNavItem(text: string): Promise<void> {
         await this.page.locator('.app-nav-primary :is(button, a)').filter({ hasText: text }).click();
-        await this.page.waitForTimeout(300);
     }
 
     async navButtonHasDiamondDecoration(text: string): Promise<boolean> {
-        const count = await this.page.locator('.app-nav__btn').filter({ hasText: text }).count();
-        return count > 0;
+        if (await this.page.locator('.app-nav__btn').filter({ hasText: text }).count() === 0) return false;
+        return this.page.evaluate((btnText) => {
+            const btns = Array.from(document.querySelectorAll('.app-nav__btn'));
+            const btn = btns.find(el => el.textContent?.trim().includes(btnText));
+            if (!btn) return false;
+            const before = window.getComputedStyle(btn, '::before');
+            const after = window.getComputedStyle(btn, '::after');
+            return (
+                before.getPropertyValue('content') !== 'none' &&
+                before.getPropertyValue('transform').includes('matrix') &&
+                after.getPropertyValue('content') !== 'none' &&
+                after.getPropertyValue('transform').includes('matrix')
+            );
+        }, text);
     }
 
     async searchBarIsVisible(): Promise<boolean> {

--- a/frontend/e2e/pages/AppPage.ts
+++ b/frontend/e2e/pages/AppPage.ts
@@ -789,4 +789,122 @@ export class AppPage {
     async countHpBoxesByType(slotType: 'solid' | 'dashed'): Promise<number> {
         return this.countSlotsByType('hp-tracker', slotType);
     }
+
+    // =============================================================================
+    // Navigation structure helpers (PBI-020)
+    // =============================================================================
+
+    async primaryNavContainsButton(text: string): Promise<boolean> {
+        const count = await this.page.locator('.app-nav-primary :is(button, a)').filter({ hasText: text }).count();
+        return count > 0;
+    }
+
+    async primaryNavHasNoSrdCategoryLinks(): Promise<boolean> {
+        const count = await this.page.locator('.app-nav-primary .type-menu').count();
+        return count === 0;
+    }
+
+    async secondaryNavIsVisible(): Promise<boolean> {
+        const count = await this.page.locator('#compendium-nav').count();
+        return count > 0;
+    }
+
+    async secondaryNavIsHidden(): Promise<boolean> {
+        const count = await this.page.locator('#compendium-nav').count();
+        return count === 0;
+    }
+
+    async secondaryNavContainsSrdLinks(): Promise<boolean> {
+        const count = await this.page.locator('#compendium-nav .type-menu button').count();
+        return count > 0;
+    }
+
+    async clickPrimaryNavItem(text: string): Promise<void> {
+        await this.page.locator('.app-nav-primary :is(button, a)').filter({ hasText: text }).click();
+        await this.page.waitForTimeout(300);
+    }
+
+    async navButtonHasDiamondDecoration(text: string): Promise<boolean> {
+        const count = await this.page.locator('.app-nav__btn').filter({ hasText: text }).count();
+        return count > 0;
+    }
+
+    async searchBarIsVisible(): Promise<boolean> {
+        return this.page.locator('form.search-bar').isVisible();
+    }
+
+    async navigateToCompendiumItem(): Promise<void> {
+        await this.page.goto(`${APP_URL}/weapons/Iron-Sword.md`);
+        await this.page.waitForTimeout(500);
+    }
+
+    // =============================================================================
+    // Character sheet layout helpers (PBI-021)
+    // =============================================================================
+
+    async identityRowSpansFullWidth(): Promise<boolean> {
+        const exists = await this.page.locator('[data-testid="identity-row"]').count();
+        const insideColumns = await this.page.locator(
+            '.character-sheet__columns [data-testid="identity-row"]'
+        ).count();
+        return exists > 0 && insideColumns === 0;
+    }
+
+    async traitsRowExistsOutsideColumnsGrid(): Promise<boolean> {
+        const exists = await this.page.locator('[data-testid="traits-row"]').count();
+        const insideColumns = await this.page.locator(
+            '.character-sheet__columns [data-testid="traits-row"]'
+        ).count();
+        return exists > 0 && insideColumns === 0;
+    }
+
+    async identityRowIsAboveTraitsRow(): Promise<boolean> {
+        const identityBox = await this.page.locator('[data-testid="identity-row"]').boundingBox();
+        const traitsBox = await this.page.locator('[data-testid="traits-row"]').boundingBox();
+        if (!identityBox || !traitsBox) return false;
+        return identityBox.y < traitsBox.y;
+    }
+
+    async damageHealthSectionExistsInColumnsGrid(): Promise<boolean> {
+        const count = await this.page.locator(
+            '.character-sheet__columns [data-testid="damage-health-section"]'
+        ).count();
+        return count > 0;
+    }
+
+    async fillCharacterNameField(value: string): Promise<void> {
+        await this.page.locator('#character-name').fill(value);
+    }
+
+    async getCharacterNameFieldValue(): Promise<string> {
+        return this.page.locator('#character-name').inputValue();
+    }
+
+    // =============================================================================
+    // Damage threshold inline helpers (PBI-022)
+    // =============================================================================
+
+    async damageThresholdsInlineRowExists(): Promise<boolean> {
+        const count = await this.page.locator('[data-testid="damage-thresholds-inline"]').count();
+        return count > 0;
+    }
+
+    async getDamageThresholdInputCount(): Promise<number> {
+        return this.page.locator('[data-testid="damage-thresholds-inline"] input[type="number"]').count();
+    }
+
+    async damageThresholdRowHasLabel(labelText: string): Promise<boolean> {
+        const text = await this.page.locator('[data-testid="damage-thresholds-inline"]').textContent();
+        return (text ?? '').includes(labelText);
+    }
+
+    async fillDamageThresholdInput(position: 1 | 2, value: string): Promise<void> {
+        const testId = position === 1 ? 'threshold-minor' : 'threshold-major';
+        await this.page.locator(`[data-testid="${testId}"]`).fill(value);
+    }
+
+    async getDamageThresholdInputValue(position: 1 | 2): Promise<string> {
+        const testId = position === 1 ? 'threshold-minor' : 'threshold-major';
+        return this.page.locator(`[data-testid="${testId}"]`).inputValue();
+    }
 }

--- a/frontend/e2e/steps/appSteps.ts
+++ b/frontend/e2e/steps/appSteps.ts
@@ -1490,3 +1490,211 @@ Then('all experience modifier fields are empty', async function (this: CustomWor
     const appPage = new AppPage(this.page);
     expect(await appPage.allExperienceModifierFieldsEmpty()).toBe(true);
 });
+
+// =============================================================================
+// PBI-020 @frontend — Nav restructure with Compendium dropdown
+// =============================================================================
+
+When('the user views any page', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    await appPage.navigate();
+    await appPage.waitForReady();
+});
+
+When('the user navigates to the homepage', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    await appPage.navigate();
+    await appPage.waitForReady();
+});
+
+When('the user views the homepage', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    await appPage.navigate();
+    await appPage.waitForReady();
+});
+
+When('the user views the primary navigation row', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    await appPage.navigate();
+    await appPage.waitForReady();
+});
+
+Given('the user is on the homepage', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    await appPage.navigate();
+    await appPage.waitForReady();
+});
+
+Given('the user is on the homepage with the secondary navigation row visible', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    await appPage.navigate();
+    await appPage.waitForReady();
+    expect(await appPage.secondaryNavIsVisible()).toBe(true);
+});
+
+Given('the user is on the homepage with the secondary navigation row hidden', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    await appPage.navigate();
+    await appPage.waitForReady();
+    await appPage.clickPrimaryNavItem('Compendium');
+    expect(await appPage.secondaryNavIsHidden()).toBe(true);
+});
+
+When('the user navigates directly to a compendium item page', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    await appPage.navigateToCompendiumItem();
+});
+
+When('they click the {string} button', async function (this: CustomWorld, buttonText: string) {
+    const appPage = new AppPage(this.page);
+    await appPage.clickPrimaryNavItem(buttonText);
+});
+
+Then('the primary navigation row contains a {string} button', async function (this: CustomWorld, text: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.primaryNavContainsButton(text)).toBe(true);
+});
+
+Then('the primary navigation row does not contain individual SRD category links', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.primaryNavHasNoSrdCategoryLinks()).toBe(true);
+});
+
+Then('the secondary navigation row is visible', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.secondaryNavIsVisible()).toBe(true);
+});
+
+Then('it contains links for all SRD categories', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.secondaryNavContainsSrdLinks()).toBe(true);
+});
+
+Then('the secondary navigation row contains links for all SRD categories', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.secondaryNavContainsSrdLinks()).toBe(true);
+});
+
+Then('the secondary navigation row is hidden', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.secondaryNavIsHidden()).toBe(true);
+});
+
+Then('the character sheet page is displayed', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    await appPage.waitForCharacterSheet();
+});
+
+Then('the {string} button has the diamond corner decoration style', async function (this: CustomWorld, buttonText: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.navButtonHasDiamondDecoration(buttonText)).toBe(true);
+});
+
+Then('the search bar is visible in the navigation area', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.searchBarIsVisible()).toBe(true);
+});
+
+// =============================================================================
+// PBI-021 @frontend — Character sheet identity row full-width and traits layout
+// =============================================================================
+
+Then('the identity row containing the Name, Pronouns, and Class fields spans the full width of the sheet', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.identityRowSpansFullWidth()).toBe(true);
+});
+
+Then('the traits section is displayed in a 2-column layout below the identity row', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.traitsRowExistsOutsideColumnsGrid()).toBe(true);
+});
+
+Then('the identity row appears above the traits section on the character sheet', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.identityRowIsAboveTraitsRow()).toBe(true);
+});
+
+Then('the Damage and Health section appears below the traits section', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.damageHealthSectionExistsInColumnsGrid()).toBe(true);
+});
+
+Then('it is displayed in the 2-column layout', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.columnsAreDisplayedSideBySide()).toBe(true);
+});
+
+When('the user enters {string} in the Name field', async function (this: CustomWorld, value: string) {
+    const appPage = new AppPage(this.page);
+    await appPage.fillCharacterNameField(value);
+});
+
+Then('the Name field displays {string}', async function (this: CustomWorld, expected: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.getCharacterNameFieldValue()).toBe(expected);
+});
+
+When('the user enters {string} in the Agility trait input', async function (this: CustomWorld, value: string) {
+    const appPage = new AppPage(this.page);
+    await appPage.fillTraitScore('agility', value);
+});
+
+Then('the Agility trait input displays {string}', async function (this: CustomWorld, expected: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.getTraitScoreValue('agility')).toBe(expected);
+});
+
+// =============================================================================
+// PBI-022 @frontend — Damage thresholds inline 2-input row
+// =============================================================================
+
+Then('the damage threshold row displays {string} followed by an input field', async function (this: CustomWorld, labelText: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.damageThresholdsInlineRowExists()).toBe(true);
+    expect(await appPage.damageThresholdRowHasLabel(labelText)).toBe(true);
+});
+
+Then('then {string} followed by an input field', async function (this: CustomWorld, labelText: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.damageThresholdRowHasLabel(labelText)).toBe(true);
+});
+
+Then('then {string} as a trailing label', async function (this: CustomWorld, labelText: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.damageThresholdRowHasLabel(labelText)).toBe(true);
+});
+
+Then('the damage threshold section contains exactly {int} input fields', async function (this: CustomWorld, count: number) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.getDamageThresholdInputCount()).toBe(count);
+});
+
+When('the user enters {string} in the first damage threshold input', async function (this: CustomWorld, value: string) {
+    const appPage = new AppPage(this.page);
+    await appPage.fillDamageThresholdInput(1, value);
+});
+
+When('the user enters {string} in the second damage threshold input', async function (this: CustomWorld, value: string) {
+    const appPage = new AppPage(this.page);
+    await appPage.fillDamageThresholdInput(2, value);
+});
+
+Then('the first damage threshold input displays {string}', async function (this: CustomWorld, expected: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.getDamageThresholdInputValue(1)).toBe(expected);
+});
+
+Then('the second damage threshold input displays {string}', async function (this: CustomWorld, expected: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.getDamageThresholdInputValue(2)).toBe(expected);
+});
+
+Then('the first damage threshold input still displays {string}', async function (this: CustomWorld, expected: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.getDamageThresholdInputValue(1)).toBe(expected);
+});
+
+Then('the second damage threshold input still displays {string}', async function (this: CustomWorld, expected: string) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.getDamageThresholdInputValue(2)).toBe(expected);
+});

--- a/frontend/e2e/steps/appSteps.ts
+++ b/frontend/e2e/steps/appSteps.ts
@@ -1525,20 +1525,6 @@ Given('the user is on the homepage', async function (this: CustomWorld) {
     await appPage.waitForReady();
 });
 
-Given('the user is on the homepage with the secondary navigation row visible', async function (this: CustomWorld) {
-    const appPage = new AppPage(this.page);
-    await appPage.navigate();
-    await appPage.waitForReady();
-    expect(await appPage.secondaryNavIsVisible()).toBe(true);
-});
-
-Given('the user is on the homepage with the secondary navigation row hidden', async function (this: CustomWorld) {
-    const appPage = new AppPage(this.page);
-    await appPage.navigate();
-    await appPage.waitForReady();
-    await appPage.clickPrimaryNavItem('Compendium');
-    expect(await appPage.secondaryNavIsHidden()).toBe(true);
-});
 
 When('the user navigates directly to a compendium item page', async function (this: CustomWorld) {
     const appPage = new AppPage(this.page);
@@ -1604,7 +1590,7 @@ Then('the identity row containing the Name, Pronouns, and Class fields spans the
     expect(await appPage.identityRowSpansFullWidth()).toBe(true);
 });
 
-Then('the traits section is displayed in a 2-column layout below the identity row', async function (this: CustomWorld) {
+Then('the traits section is displayed as a full-width inline row below the identity row', async function (this: CustomWorld) {
     const appPage = new AppPage(this.page);
     expect(await appPage.traitsRowExistsOutsideColumnsGrid()).toBe(true);
 });

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -631,14 +631,25 @@ main {
 }
 
 /* ============================================================
-   App Navigation (Character Sheet link)
+   App Navigation — primary and secondary rows
    ============================================================ */
 
-.app-nav {
+.app-nav-primary {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1rem;
   margin-top: 0.5rem;
+  padding-bottom: 0.25rem;
 }
 
-.app-nav__link {
+.app-nav-secondary {
+  border-top: 1px solid rgba(212, 176, 79, 0.3);
+  padding-top: 0.25rem;
+}
+
+.app-nav__btn {
+  position: relative;
   display: inline-block;
   padding: 0.5rem 1.2rem;
   border: 2px solid #d4b04f;
@@ -646,23 +657,50 @@ main {
   color: #ffd166;
   font-weight: bold;
   border-radius: 0.3rem;
+  cursor: pointer;
   text-decoration: none;
+  font-size: inherit;
+  font-family: inherit;
   transition: all 0.2s ease-in-out;
 }
 
-.app-nav__link:hover {
+.app-nav__btn::before,
+.app-nav__btn::after {
+  content: '';
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background: #d4b04f;
+  transform: rotate(45deg);
+}
+
+.app-nav__btn::before {
+  top: -5px;
+  left: -5px;
+}
+
+.app-nav__btn::after {
+  bottom: -5px;
+  right: -5px;
+}
+
+.app-nav__btn:hover {
   background-color: #6b4cd6;
   color: white;
   border-color: #ffd166;
 }
 
-.dark-mode .app-nav__link {
+.app-nav__btn--open {
+  opacity: 0.85;
+}
+
+.dark-mode .app-nav__btn {
   background-color: #2d1950;
   color: #ffd166;
   border-color: #a88b32;
 }
 
-.dark-mode .app-nav__link:hover {
+.dark-mode .app-nav__btn:hover {
   background-color: #3a2472;
   color: white;
   border-color: #ffd166;
@@ -689,6 +727,11 @@ main {
   color: #ffd166;
 }
 
+.character-sheet__identity-row,
+.character-sheet__traits-row {
+  margin-bottom: 1rem;
+}
+
 .character-sheet__columns {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -699,6 +742,16 @@ main {
 @media (max-width: 768px) {
   .character-sheet__columns {
     grid-template-columns: 1fr;
+  }
+
+  .traits-section__columns {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .traits-section__columns {
+    grid-template-columns: repeat(2, 1fr);
   }
 }
 
@@ -905,7 +958,7 @@ main {
 
 .traits-section__columns {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(6, 1fr);
   gap: 0.75rem;
 }
 
@@ -1046,6 +1099,14 @@ main {
 
 .damage-health-section__thresholds {
   margin-bottom: 1rem;
+}
+
+.damage-health-section__thresholds-inline {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
 }
 
 .damage-health-section__threshold-row {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Routes, Route, Link, useNavigate, useParams } from 'react-router-dom';
+import { Routes, Route, Link, useNavigate, useParams, useLocation } from 'react-router-dom';
 import { CharacterSheetPage } from './features/character-sheet';
 import SearchBar from './components/SearchBar';
 import ItemList from './components/ItemList';
@@ -44,6 +44,7 @@ function App({ serverUrl }: AppProps) {
   const { types } = useSrdTypes(serverUrl);
   const { items, search, filterByType } = useSrdSearch(serverUrl);
   const navigate = useNavigate();
+  const location = useLocation();
 
   const [darkMode, setDarkMode] = useState<boolean>(() => {
     const stored = localStorage.getItem('darkMode');
@@ -54,6 +55,8 @@ function App({ serverUrl }: AppProps) {
       window.matchMedia('(prefers-color-scheme: dark)').matches;
   });
 
+  const [isCompendiumOpen, setIsCompendiumOpen] = useState<boolean>(true);
+
   useEffect(() => {
     if (darkMode) {
       document.body.classList.add('dark-mode');
@@ -63,6 +66,10 @@ function App({ serverUrl }: AppProps) {
       document.documentElement.classList.remove('dark-mode');
     }
   }, [darkMode]);
+
+  useEffect(() => {
+    setIsCompendiumOpen(location.pathname !== '/character-sheet');
+  }, [location.pathname]);
 
   const toggleDarkMode = () => {
     setDarkMode(dm => {
@@ -98,10 +105,28 @@ function App({ serverUrl }: AppProps) {
           {!darkMode ? '🌙' : '☀️'}
         </button>
         <SearchBar onSearch={handleSearch} />
-        <TypeMenu types={types} onTypeClick={handleTypeClick} />
-        <nav className="app-nav">
-          <Link to="/character-sheet" className="app-nav__link">Character Sheet</Link>
+        <nav className="app-nav-primary" aria-label="Primary navigation">
+          <button
+            className={`app-nav__btn${isCompendiumOpen ? ' app-nav__btn--open' : ''}`}
+            onClick={() => setIsCompendiumOpen(o => !o)}
+            aria-expanded={isCompendiumOpen}
+            aria-controls="compendium-nav"
+          >
+            Compendium
+          </button>
+          <Link to="/character-sheet" className="app-nav__btn">
+            Character Sheet
+          </Link>
         </nav>
+        {isCompendiumOpen && (
+          <nav
+            id="compendium-nav"
+            className="app-nav-secondary"
+            aria-label="Compendium categories"
+          >
+            <TypeMenu types={types} onTypeClick={handleTypeClick} />
+          </nav>
+        )}
       </header>
       <main>
         <Routes>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -118,6 +118,7 @@ function App({ serverUrl }: AppProps) {
             Character Sheet
           </Link>
         </nav>
+        {/* Conditional render (DOM removal) rather than display:none — stronger than aria-hidden for AT */}
         {isCompendiumOpen && (
           <nav
             id="compendium-nav"

--- a/frontend/src/features/character-sheet/components/CharacterSheetPage.tsx
+++ b/frontend/src/features/character-sheet/components/CharacterSheetPage.tsx
@@ -16,11 +16,14 @@ function CharacterSheetPageInner(): React.ReactElement {
   return (
     <div className="character-sheet" data-testid="character-sheet">
       <h1 className="character-sheet__title">Character Sheet</h1>
+      <div className="character-sheet__identity-row" data-testid="identity-row">
+        <ClassHeader />
+      </div>
+      <div className="character-sheet__traits-row" data-testid="traits-row">
+        <TraitsSection />
+      </div>
       <div className="character-sheet__columns">
         <div className="character-sheet__column character-sheet__column--left" data-testid="left-column">
-          <ClassHeader />
-          {/* Traits & Defence (PBI-010) */}
-          <TraitsSection />
           <DefenceSection />
           <DamageHealthSection />
           <HopeSection />
@@ -33,7 +36,6 @@ function CharacterSheetPageInner(): React.ReactElement {
           <InventorySection />
         </div>
       </div>
-      {/* Class Feature spans full width below the two-column grid (PBI-016) */}
       <ClassFeatureSection />
     </div>
   );

--- a/frontend/src/features/character-sheet/components/DamageHealthSection.tsx
+++ b/frontend/src/features/character-sheet/components/DamageHealthSection.tsx
@@ -15,7 +15,7 @@ function DamageHealthSection(): React.ReactElement {
   } = useCharacterHealth();
 
   function handleThresholdChange(
-    key: 'minor' | 'major' | 'severe',
+    key: 'minor' | 'major',
     rawValue: string
   ): void {
     const parsed = parseInt(rawValue, 10);
@@ -30,63 +30,41 @@ function DamageHealthSection(): React.ReactElement {
     >
       <h2>Damage &amp; Health</h2>
 
-      <div className="damage-health-section__thresholds">
+      <div className="damage-health-section__thresholds" data-testid="damage-thresholds">
         <p className="damage-health-section__hint" data-testid="damage-threshold-hint">
           Add your current level
         </p>
 
-        <div className="damage-health-section__threshold-row">
-          <label
-            className="damage-health-section__threshold-label"
-            htmlFor="threshold-minor"
-          >
+        <div className="damage-health-section__thresholds-inline" data-testid="damage-thresholds-inline">
+          <span className="damage-health-section__threshold-label" data-testid="threshold-label-minor">
             Minor Damage
-          </label>
+          </span>
           <input
             id="threshold-minor"
             className="damage-health-section__threshold-input"
             type="number"
-            aria-label="Minor Damage threshold"
+            min={0}
+            aria-label="Minor to Major damage threshold"
             data-testid="threshold-minor"
             value={damageThresholds.minor ?? ''}
             onChange={(e) => handleThresholdChange('minor', e.target.value)}
           />
-        </div>
-
-        <div className="damage-health-section__threshold-row">
-          <label
-            className="damage-health-section__threshold-label"
-            htmlFor="threshold-major"
-          >
+          <span className="damage-health-section__threshold-label" data-testid="threshold-label-major">
             Major Damage
-          </label>
+          </span>
           <input
             id="threshold-major"
             className="damage-health-section__threshold-input"
             type="number"
-            aria-label="Major Damage threshold"
+            min={0}
+            aria-label="Major to Severe damage threshold"
             data-testid="threshold-major"
             value={damageThresholds.major ?? ''}
             onChange={(e) => handleThresholdChange('major', e.target.value)}
           />
-        </div>
-
-        <div className="damage-health-section__threshold-row">
-          <label
-            className="damage-health-section__threshold-label"
-            htmlFor="threshold-severe"
-          >
+          <span className="damage-health-section__threshold-label" data-testid="threshold-label-severe">
             Severe Damage
-          </label>
-          <input
-            id="threshold-severe"
-            className="damage-health-section__threshold-input"
-            type="number"
-            aria-label="Severe Damage threshold"
-            data-testid="threshold-severe"
-            value={damageThresholds.severe ?? ''}
-            onChange={(e) => handleThresholdChange('severe', e.target.value)}
-          />
+          </span>
         </div>
       </div>
 

--- a/frontend/src/features/character-sheet/context/CharacterContext.tsx
+++ b/frontend/src/features/character-sheet/context/CharacterContext.tsx
@@ -22,7 +22,7 @@ const initialState: CharacterState = {
   armorSlots: Array(6).fill(false) as boolean[],
 
   hpSolidCount: 6,
-  damageThresholds: { minor: null, major: null, severe: null },
+  damageThresholds: { minor: null, major: null },
   hpSlots: Array(10).fill(false) as boolean[],
   stressSlots: Array(8).fill(false) as boolean[],
 

--- a/frontend/src/features/character-sheet/hooks/useCharacterHealth.ts
+++ b/frontend/src/features/character-sheet/hooks/useCharacterHealth.ts
@@ -7,7 +7,7 @@ interface UseCharacterHealthResult {
   damageThresholds: CharacterState['damageThresholds'];
   hpSlots: boolean[];
   stressSlots: boolean[];
-  setDamageThreshold: (key: 'minor' | 'major' | 'severe', value: number | null) => void;
+  setDamageThreshold: (key: 'minor' | 'major', value: number | null) => void;
   toggleHpSlot: (index: number) => void;
   toggleStressSlot: (index: number) => void;
 }
@@ -16,7 +16,7 @@ export function useCharacterHealth(): UseCharacterHealthResult {
   const { state, dispatch } = useCharacterContext();
 
   const setDamageThreshold = useCallback(
-    (key: 'minor' | 'major' | 'severe', value: number | null) => {
+    (key: 'minor' | 'major', value: number | null) => {
       dispatch({ type: 'SET_DAMAGE_THRESHOLD', payload: { key, value } });
     },
     [dispatch]

--- a/frontend/src/features/character-sheet/types/character.ts
+++ b/frontend/src/features/character-sheet/types/character.ts
@@ -49,7 +49,7 @@ export interface CharacterState {
 
   // Health (PBI-011, PBI-017)
   hpSolidCount: number;
-  damageThresholds: { minor: number | null; major: number | null; severe: number | null };
+  damageThresholds: { minor: number | null; major: number | null };
   hpSlots: boolean[];
   stressSlots: boolean[];
 
@@ -73,7 +73,7 @@ export type CharacterAction =
   | { type: 'SET_EVASION'; payload: number }
   | { type: 'SET_ARMOR_SCORE'; payload: number | null }
   | { type: 'TOGGLE_ARMOR_SLOT'; payload: number }
-  | { type: 'SET_DAMAGE_THRESHOLD'; payload: { key: 'minor' | 'major' | 'severe'; value: number | null } }
+  | { type: 'SET_DAMAGE_THRESHOLD'; payload: { key: 'minor' | 'major'; value: number | null } }
   | { type: 'TOGGLE_HP_SLOT'; payload: number }
   | { type: 'TOGGLE_STRESS_SLOT'; payload: number }
   | { type: 'TOGGLE_HOPE_DIAMOND'; payload: number }


### PR DESCRIPTION
## Summary

- **PBI-020**: Restructures the navigation bar into a two-level layout — a primary row with diamond-decorated "Compendium" (toggle) and "Character Sheet" buttons, and a secondary row showing SRD category links. The secondary row is open by default on all routes except `/character-sheet`.
- **PBI-021**: Moves the character sheet identity fields (`ClassHeader`) and trait scores (`TraitsSection`) out of the left column into full-width rows above the two-column grid. Traits are displayed as a 6-column inline row (all six traits side by side).
- **PBI-022**: Replaces the three-row damage threshold section with a single inline row: `Minor Damage | [input] | Major Damage | [input] | Severe Damage`. The `severe` field removed from `DamageThresholds` state (ephemeral — no migration needed).

## What changed

| File | Change |
|---|---|
| `frontend/src/App.tsx` | Primary + secondary nav rows; `isCompendiumOpen` state; route-aware `useEffect` |
| `frontend/src/App.css` | Nav styles, diamond decorations, identity/traits layout rules, inline threshold styles |
| `frontend/src/features/character-sheet/components/CharacterSheetPage.tsx` | Identity and traits rows moved above column grid |
| `frontend/src/features/character-sheet/components/DamageHealthSection.tsx` | Inline threshold row with 2 inputs |
| `frontend/src/features/character-sheet/types/character.ts` | `DamageThresholds` type to `{ minor, major }` |
| `frontend/src/features/character-sheet/context/CharacterContext.tsx` | Initial state updated |
| `frontend/src/features/character-sheet/hooks/useCharacterHealth.ts` | Type signature updated |
| `frontend/e2e/pages/AppPage.ts` | Page object methods for all three PBIs |
| `frontend/e2e/steps/appSteps.ts` | Step definitions for all three PBIs |
| `dev-flow/product/PBI-021-*.feature` | Scenario 2 wording corrected to "full-width inline row" |
| `dev-flow/design/PBI-020/021/022-*-design.md` | Approved design specs |
| `dev-flow/engineering/architecture/PBI-020/021/022-*-flow.md` | Flow descriptors |

## Test plan

- [ ] All PBI-020 `@frontend` scenarios pass (10 scenarios): primary nav buttons, secondary row toggle, route-aware state, diamond decorations, search bar
- [ ] All PBI-021 `@frontend` scenarios pass (6 scenarios): identity row full-width, traits row outside columns, ordering, column grid intact, editability
- [ ] All PBI-022 `@frontend` scenarios pass (6 scenarios): inline row layout, exactly 2 inputs, independent editability, value retention
- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] No regressions on previous PBI-008–019 scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)