### PR TITLE
feat(PBI-023): compact identity bar to three columns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,9 @@ Determine what you're being asked to do, then read the corresponding guideline f
 
 ## Current State
 
-**Active increment:** None — awaiting next increment statement
+**Active increment:** Identity bar compact layout — PBI-023 complete, awaiting validation
 
-**Stage:** Increment accepted — awaiting next increment statement
+**Stage:** All PBIs complete — Increment validation in progress
 
 **Completed increments:**
 - Foundation & compendium (PBI-001–012) ✅
@@ -98,6 +98,7 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - `PBI-020` ✅ Complete — nav restructured into primary row (Compendium + Character Sheet buttons with diamond decorations) and secondary row (SRD category links); route-aware open/closed state
 - `PBI-021` ✅ Complete — character sheet identity row (`ClassHeader`) and traits row (`TraitsSection`) moved to full-width rows above the two-column grid; traits grid changed to `repeat(6, 1fr)`
 - `PBI-022` ✅ Complete — damage thresholds rendered as inline single row with two inputs; `severe` field removed from `DamageThresholds` state
+- `PBI-023` ✅ Complete — identity bar grid changed from `1fr 1fr` to `repeat(3, 1fr)`; responsive overrides: 2 cols at ≤768px, 1 col at ≤480px
 
 **Feature files:** All complete ✅ (`dev-flow/product/`)
 - `PBI-001-security-baseline.feature` ✅
@@ -122,6 +123,7 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - `PBI-020-nav-compendium-dropdown.feature` ✅
 - `PBI-021-character-sheet-identity-traits-layout.feature` ✅
 - `PBI-022-damage-thresholds-inline.feature` ✅
+- `PBI-023-identity-bar-three-column.feature` ✅
 
 **Key constraints:**
 - Step-def method naming convention (`should_/when_`) is established as exempt for BDD step definition methods (applies only to `@Test` JUnit methods).
@@ -142,6 +144,7 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - Nav (PBI-020): `isCompendiumOpen` state in `App.tsx`; open on all routes except `/character-sheet`; implemented via conditional rendering (DOM removal) rather than `display:none` — intentional deviation from design spec, documented in code comment.
 - Character sheet layout (PBI-021): `ClassHeader` renders in `.character-sheet__identity-row`; `TraitsSection` renders in `.character-sheet__traits-row` — both are full-width wrapper divs above `.character-sheet__columns`, not inside the column grid. Traits internal grid is `repeat(6, 1fr)`; collapses to `repeat(3, 1fr)` at ≤768px and `repeat(2, 1fr)` at ≤480px.
 - Damage thresholds (PBI-022): `DamageThresholds` type is `{ minor: number | null; major: number | null }` — `severe` field removed. Inline row has `data-testid="damage-thresholds-inline"`; inputs are `data-testid="threshold-minor"` and `data-testid="threshold-major"`.
+- Identity bar (PBI-023): `.class-header__identity` grid is `repeat(3, 1fr)` at >768px, `repeat(2, 1fr)` at ≤768px, `1fr` at ≤480px. `AppPage.getIdentityGridColumnCount()` uses bounding-box row grouping (5px tolerance). `AppPage.getIdentityFieldsOnRow(n)` groups fields by y-position and returns labels for row n (1-indexed).
 - Version control: all work happens on `increment/<slug>` or `fix/PBI-XXX-<slug>` branches in the main working tree. No git worktrees (removed from guidelines 2026-05-14).
 
 **Technical debt:** `dev-flow/product/technical-debt-backlog.md`
@@ -166,7 +169,7 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - `ADR-013-weapon-armor-srd-item-types.md` — WEAPONS/ARMOR as structured SrdItem types in srd.json; HTML-parsing amendment approved 2026-05-14
 - `ADR-014-class-hp-slot-count.md` — `hpSlotCount` parsed from CLASSES content at ingestion, stored as nullable `Integer` on `SrdItem`; approved 2026-05-14
 
-**Last updated:** 2026-05-15 — PBI-020, 021, 022 completed and passed independent review; UI consolidation increment on `increment/ui-consolidation`, PR #12 open for merge
+**Last updated:** 2026-05-15 — PBI-023 completed and passed independent review; identity bar compact layout increment on `increment/identity-bar-compact`
 
 ---
 

--- a/dev-flow/design/PBI-023-identity-bar-three-column-design.md
+++ b/dev-flow/design/PBI-023-identity-bar-three-column-design.md
@@ -1,0 +1,148 @@
+# Design Specification — PBI-023: Compact identity bar — three fields per row
+
+**PBI:** PBI-023
+**Design Agent output date:** 2026-05-15
+**Status:** Draft
+
+---
+
+## 1. Feature Summary
+
+The six character identity fields (Name, Pronouns, Class, Heritage, Subclass, Level) currently occupy three rows of two fields. They will instead occupy two rows of three fields, reducing the vertical footprint of the identity bar without changing any field content, labels, or interactions.
+
+---
+
+## 2. Scope
+
+**IN scope for this design:**
+- Change the identity grid from two columns to three columns on wide viewports.
+- Add responsive breakpoints: two columns at ≤768 px, one column at ≤480 px.
+
+**OUT of scope:**
+- Field order, labels, input types, or placeholder text.
+- The domain badges row below the identity grid.
+- Dark mode colour changes.
+- Any other character sheet section.
+
+---
+
+## 3. Pages and Routes Affected
+
+| Route | Page/Component | New or Modified |
+|---|---|---|
+| `/character-sheet` | `ClassHeader` | Modified — CSS only |
+
+---
+
+## 4. Component Inventory
+
+| Component | Status | Location | Responsibility |
+|---|---|---|---|
+| `ClassHeader` | Modified (CSS only) | `src/features/character-sheet/components/ClassHeader.tsx` | No JSX changes. The `.class-header__identity` CSS class receives updated `grid-template-columns`. |
+
+---
+
+## 5. Layout and Visual Structure
+
+### Identity bar — wide viewport (>768 px)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Name               │  Pronouns           │  Class           │
+│  [_______________]  │  [_______________]  │  [▼ Select    ]  │
+├──────────────────────────────────────────────────────────────┤
+│  Heritage           │  Subclass           │  Level           │
+│  [▼ Select       ]  │  [▼ Select       ]  │  [__]            │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Grid:** `repeat(3, 1fr)` — equal-width columns, existing `gap: 0.75rem` unchanged.
+
+### Identity bar — tablet viewport (≤768 px)
+
+```
+┌──────────────────────────────────────┐
+│  Name               │  Pronouns       │
+│  [_______________]  │  [___________]  │
+├──────────────────────────────────────┤
+│  Class              │  Heritage       │
+│  [▼ Select       ]  │  [▼ Select  ]   │
+├──────────────────────────────────────┤
+│  Subclass           │  Level          │
+│  [▼ Select       ]  │  [__]           │
+└──────────────────────────────────────┘
+```
+
+**Grid:** `repeat(2, 1fr)` — three rows of two.
+
+### Identity bar — small mobile viewport (≤480 px)
+
+```
+┌────────────────────────┐
+│  Name                  │
+│  [__________________]  │
+├────────────────────────┤
+│  Pronouns              │
+│  [__________________]  │
+│  … (one per row)       │
+└────────────────────────┘
+```
+
+**Grid:** `1fr` — single column, six rows.
+
+**Sizing and spacing notes:**
+- Gap remains `0.75rem` at all breakpoints — no change.
+- Level input remains narrow (it is a number field); the grid column gives it the same allocated space as other fields, which is fine — the input itself is narrower than the column.
+
+**Responsive behaviour:**
+- >768 px → `repeat(3, 1fr)`
+- ≤768 px → `repeat(2, 1fr)`
+- ≤480 px → `1fr`
+
+---
+
+## 6. Interaction Specification
+
+No new interactions. All existing field interactions (text input, dropdown selection, number input) are unchanged. This design only changes the spatial arrangement.
+
+---
+
+## 7. Copy and Labels
+
+No changes to any copy or labels.
+
+---
+
+## 8. Accessibility Notes
+
+- Focus order follows DOM order, which matches the visual left-to-right, top-to-bottom reading order in all three grid states. No focus management changes needed.
+- No new ARIA labels required.
+- No new colours introduced.
+
+---
+
+## 9. Design Decisions and Rationale
+
+| Decision | Alternatives considered | Rationale |
+|---|---|---|
+| Collapse to 2 cols at ≤768 px (not 1 col) | 1 col at ≤768 px | Consistent with the traits section behaviour (`repeat(3, 1fr)` → `repeat(3, 1fr)` at ≤768 px then narrower). Two columns at tablet is readable without wasting space. |
+| Collapse to 1 col at ≤480 px | Staying at 2 cols | At ≤480 px the fields would be too narrow for readable dropdown labels; single column is the correct choice. Human confirmed this preference. |
+| No change to field order | Reorder fields for the 3-col layout | Field order (Name, Pronouns, Class, Heritage, Subclass, Level) is established and familiar. Reordering would break the acceptance scenario for field order. |
+
+---
+
+## 10. Open Design Questions
+
+No open design questions.
+
+---
+
+## 11. Scenario Traceability
+
+| Scenario | Addressed by |
+|---|---|
+| "Identity fields render in three columns on a wide viewport" | Section 5 — wide viewport layout |
+| "Field order is preserved in the three-column layout" | Section 5 — field order is left-to-right DOM order; Section 9 — no reordering decision |
+| "Identity grid collapses to two columns on a tablet viewport" | Section 5 — tablet layout; responsive behaviour notes |
+| "Identity grid collapses to one column on a small mobile viewport" | Section 5 — small mobile layout; responsive behaviour notes |
+| "All six identity fields remain visible and operable after layout change" | Section 4 — no JSX changes; Section 6 — interactions unchanged |

--- a/dev-flow/engineering/architecture/PBI-023-identity-bar-three-column-flow.md
+++ b/dev-flow/engineering/architecture/PBI-023-identity-bar-three-column-flow.md
@@ -1,0 +1,50 @@
+# Flow Descriptor — PBI-023: Compact identity bar — three fields per row
+
+**PBI:** PBI-023
+**Architecture Agent output date:** 2026-05-15
+**ADR required:** No
+
+---
+
+## 1. What This Builds
+
+Changes the `.class-header__identity` CSS grid from two equal columns (`1fr 1fr`) to three equal columns (`repeat(3, 1fr)`), compacting the six identity fields from three rows into two. Adds responsive overrides to collapse to two columns at ≤768 px and one column at ≤480 px.
+
+No JSX, no logic, no hooks, and no backend components are touched.
+
+---
+
+## 2. Component Map
+
+| Component | Layer | Change |
+|---|---|---|
+| `.class-header__identity` (CSS rule in `App.css`) | Frontend — styles | `grid-template-columns` updated |
+| `@media (max-width: 768px)` block in `App.css` | Frontend — styles | New rule for `.class-header__identity` added |
+| `@media (max-width: 480px)` block in `App.css` | Frontend — styles | New rule for `.class-header__identity` added |
+| `ClassHeader.tsx` | Frontend — component | No change |
+
+---
+
+## 3. Data Flow
+
+No data flow change. The identity fields are already rendered and wired to `useCharacterIdentity`. This change affects presentation only.
+
+---
+
+## 4. API Contract
+
+No API changes.
+
+---
+
+## 5. Security Notes
+
+No security implications. This is a CSS layout change with no user input surface changes and no trust boundary crossings.
+
+---
+
+## 6. Consistency Notes
+
+Follows the established pattern for responsive grid adjustments in `App.css`. The existing `@media (max-width: 768px)` and `@media (max-width: 480px)` blocks (which govern `.character-sheet__columns` and `.traits-section__columns`) are the direct precedent. The new rules are added to those same blocks.
+
+No ADR is required: no new external dependency, no new pattern, no API or data model change, no trade-off between competing approaches.

--- a/dev-flow/product/PBI-023-identity-bar-three-column.feature
+++ b/dev-flow/product/PBI-023-identity-bar-three-column.feature
@@ -1,0 +1,39 @@
+Feature: Compact identity bar — three fields per row
+  As a player using the character sheet,
+  I want the six identity fields to appear across two rows of three,
+  So that the identity bar is more compact and less vertical space is consumed.
+  Backlog item: PBI-023
+
+  Background:
+    Given the user has navigated to the character sheet
+
+  @smoke @frontend
+  Scenario: Identity fields render in three columns on a wide viewport
+    Given the viewport is 1024px wide
+    Then the identity bar displays three fields on the first row: "Name", "Pronouns", and "Class"
+    And the identity bar displays three fields on the second row: "Heritage", "Subclass", and "Level"
+
+  @regression @frontend
+  Scenario: Field order is preserved in the three-column layout
+    Given the viewport is 1024px wide
+    Then the identity fields appear in order: "Name", "Pronouns", "Class", "Heritage", "Subclass", "Level"
+
+  @regression @frontend
+  Scenario: Identity grid collapses to two columns on a tablet viewport
+    Given the viewport is 768px wide
+    Then the identity bar displays two fields per row
+
+  @regression @frontend
+  Scenario: Identity grid collapses to one column on a small mobile viewport
+    Given the viewport is 480px wide
+    Then the identity bar displays one field per row
+
+  @regression @frontend
+  Scenario: All six identity fields remain visible and operable after layout change
+    Given the viewport is 1024px wide
+    When the user types "Seraphina" into the "Name" field
+    And the user types "she/her" into the "Pronouns" field
+    And the user selects a class from the "Class" dropdown
+    And the user selects a heritage from the "Heritage" dropdown
+    And the user enters "3" into the "Level" field
+    Then all entered values are visible in the identity bar

--- a/frontend/e2e/pages/AppPage.ts
+++ b/frontend/e2e/pages/AppPage.ts
@@ -918,4 +918,87 @@ export class AppPage {
         const testId = position === 1 ? 'threshold-minor' : 'threshold-major';
         return this.page.locator(`[data-testid="${testId}"]`).inputValue();
     }
+
+    // =============================================================================
+    // Identity bar layout helpers (PBI-023)
+    // =============================================================================
+
+    async setViewportWidth(width: number): Promise<void> {
+        await this.page.setViewportSize({ width, height: 800 });
+        await this.page.waitForTimeout(100);
+    }
+
+    async getIdentityGridColumnCount(): Promise<number> {
+        await this.page.waitForSelector('.class-header__identity', { timeout: 5000 });
+        return this.page.evaluate(() => {
+            const container = document.querySelector('.class-header__identity');
+            if (!container) return 0;
+            const fields = Array.from(container.querySelectorAll('.class-header__field'));
+            if (fields.length === 0) return 0;
+            const firstTop = Math.round(fields[0].getBoundingClientRect().top);
+            return fields.filter(
+                (f) => Math.abs(Math.round(f.getBoundingClientRect().top) - firstTop) < 5,
+            ).length;
+        });
+    }
+
+    async getIdentityFieldsOnRow(rowIndex: number): Promise<string[]> {
+        await this.page.waitForSelector('.class-header__identity', { timeout: 5000 });
+        return this.page.evaluate((row) => {
+            const container = document.querySelector('.class-header__identity');
+            if (!container) return [];
+            const fields = Array.from(container.querySelectorAll('.class-header__field'));
+            const rowGroups = new Map<number, string[]>();
+            for (const field of fields) {
+                const top = Math.round(field.getBoundingClientRect().top);
+                const label = field.querySelector('label')?.textContent?.trim() ?? '';
+                const existingKey = Array.from(rowGroups.keys()).find((k) => Math.abs(k - top) < 5);
+                if (existingKey !== undefined) {
+                    rowGroups.get(existingKey)!.push(label);
+                } else {
+                    rowGroups.set(top, [label]);
+                }
+            }
+            const sortedKeys = Array.from(rowGroups.keys()).sort((a, b) => a - b);
+            if (row - 1 >= sortedKeys.length) return [];
+            return rowGroups.get(sortedKeys[row - 1]) ?? [];
+        }, rowIndex);
+    }
+
+    async getIdentityFieldOrder(): Promise<string[]> {
+        await this.page.waitForSelector('.class-header__identity', { timeout: 5000 });
+        return this.page.evaluate(() => {
+            const container = document.querySelector('.class-header__identity');
+            if (!container) return [];
+            return Array.from(container.querySelectorAll('.class-header__field label')).map(
+                (el) => el.textContent?.trim() ?? '',
+            );
+        });
+    }
+
+    async allIdentityFieldsAreVisible(): Promise<boolean> {
+        await this.page.waitForSelector('.class-header__identity', { timeout: 5000 });
+        return this.page.evaluate(() => {
+            const container = document.querySelector('.class-header__identity');
+            if (!container) return false;
+            const fields = Array.from(container.querySelectorAll('.class-header__field'));
+            return fields.every((f) => {
+                const rect = f.getBoundingClientRect();
+                return rect.height > 0 && rect.width > 0;
+            });
+        });
+    }
+
+    async selectFirstOptionFromDropdown(ariaLabel: string): Promise<void> {
+        const select = this.page.locator(`select[aria-label="${ariaLabel}"]`);
+        await select.waitFor({ timeout: 10000 });
+        const options = await select.locator('option').all();
+        if (options.length > 1) {
+            const firstOptionValue = await options[1].getAttribute('value');
+            if (firstOptionValue) {
+                await select.selectOption({ value: firstOptionValue });
+            }
+        }
+        await this.page.waitForTimeout(300);
+    }
 }

--- a/frontend/e2e/steps/appSteps.ts
+++ b/frontend/e2e/steps/appSteps.ts
@@ -1675,6 +1675,77 @@ Then('the second damage threshold input displays {string}', async function (this
     expect(await appPage.getDamageThresholdInputValue(2)).toBe(expected);
 });
 
+// =============================================================================
+// PBI-023 @frontend — Identity bar three-column layout
+// =============================================================================
+
+Given('the user has navigated to the character sheet', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    await appPage.navigateToCharacterSheet();
+    await appPage.waitForCharacterSheet();
+});
+
+Given('the viewport is {int}px wide', async function (this: CustomWorld, width: number) {
+    const appPage = new AppPage(this.page);
+    await appPage.setViewportWidth(width);
+});
+
+Then('the identity bar displays three fields on the first row: {string}, {string}, and {string}',
+    async function (this: CustomWorld, f1: string, f2: string, f3: string) {
+        const appPage = new AppPage(this.page);
+        const fields = await appPage.getIdentityFieldsOnRow(1);
+        expect(fields).toEqual([f1, f2, f3]);
+    },
+);
+
+Then('the identity bar displays three fields on the second row: {string}, {string}, and {string}',
+    async function (this: CustomWorld, f1: string, f2: string, f3: string) {
+        const appPage = new AppPage(this.page);
+        const fields = await appPage.getIdentityFieldsOnRow(2);
+        expect(fields).toEqual([f1, f2, f3]);
+    },
+);
+
+Then('the identity fields appear in order: {string}, {string}, {string}, {string}, {string}, {string}',
+    async function (this: CustomWorld, f1: string, f2: string, f3: string, f4: string, f5: string, f6: string) {
+        const appPage = new AppPage(this.page);
+        const order = await appPage.getIdentityFieldOrder();
+        expect(order).toEqual([f1, f2, f3, f4, f5, f6]);
+    },
+);
+
+Then('the identity bar displays two fields per row', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    const count = await appPage.getIdentityGridColumnCount();
+    expect(count).toBe(2);
+});
+
+Then('the identity bar displays one field per row', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    const count = await appPage.getIdentityGridColumnCount();
+    expect(count).toBe(1);
+});
+
+When('the user types {string} into the {string} field', async function (this: CustomWorld, value: string, fieldLabel: string) {
+    const appPage = new AppPage(this.page);
+    await appPage.fillTextField(fieldLabel, value);
+});
+
+When('the user selects a class from the {string} dropdown', async function (this: CustomWorld, dropdownLabel: string) {
+    const appPage = new AppPage(this.page);
+    await appPage.selectFirstOptionFromDropdown(dropdownLabel);
+});
+
+When('the user enters {string} into the {string} field', async function (this: CustomWorld, value: string, fieldLabel: string) {
+    const appPage = new AppPage(this.page);
+    await appPage.fillTextField(fieldLabel, value);
+});
+
+Then('all entered values are visible in the identity bar', async function (this: CustomWorld) {
+    const appPage = new AppPage(this.page);
+    expect(await appPage.allIdentityFieldsAreVisible()).toBe(true);
+});
+
 Then('the first damage threshold input still displays {string}', async function (this: CustomWorld, expected: string) {
     const appPage = new AppPage(this.page);
     expect(await appPage.getDamageThresholdInputValue(1)).toBe(expected);

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -747,11 +747,19 @@ main {
   .traits-section__columns {
     grid-template-columns: repeat(3, 1fr);
   }
+
+  .class-header__identity {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 @media (max-width: 480px) {
   .traits-section__columns {
     grid-template-columns: repeat(2, 1fr);
+  }
+
+  .class-header__identity {
+    grid-template-columns: 1fr;
   }
 }
 
@@ -865,7 +873,7 @@ main {
 
 .class-header__identity {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: repeat(3, 1fr);
   gap: 0.75rem;
 }
 


### PR DESCRIPTION
## Summary

- Changes `.class-header__identity` CSS grid from `1fr 1fr` (2 cols) to `repeat(3, 1fr)` (3 cols), reducing the identity bar from 3 rows to 2 rows on wide viewports
- Adds responsive breakpoints: `repeat(2, 1fr)` at ≤768 px, `1fr` at ≤480 px — consistent with the existing traits section pattern
- Adds e2e step definitions and AppPage helpers for PBI-023 acceptance scenarios
- No JSX, no logic, no hooks, no backend changes

## Test plan

- [ ] Character sheet loads and identity bar shows 6 fields in 2 rows (3 per row) on wide viewport
- [ ] Field order preserved: Name, Pronouns, Class, Heritage, Subclass, Level
- [ ] Resize to ≤768 px → 2 fields per row (3 rows)
- [ ] Resize to ≤480 px → 1 field per row (6 rows)
- [ ] All fields remain operable after layout change
- [ ] `npm run test:e2e` passes for PBI-023 scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)