### PR TITLE
docs(dev-flow): retrospective improvements — tier system, leaner CLAUDE.md, validation and state update fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,18 +22,18 @@ daggerheart-tools/
 
 All work on this project follows the process defined in `dev-flow/`. The short version:
 
-1. **Product track** — increment is broken into PBIs → prioritised → acceptance scenarios written (`.feature` files in `dev-flow/product/`)
+1. **Product track** — increment is broken into PBIs → prioritised → acceptance scenarios written (`.feature` files in `dev-flow/product/`). Each PBI is classified as `minor`, `standard`, or `significant` — see `dev-flow/product/product-track-guidelines.md` for what each tier skips.
 2. **Human checkpoint** — human approves scenarios
-3. **Design** — Design Agent produces a Design Specification for any PBI with frontend scope (skipped for backend-only PBIs)
+3. **Design** — Design Agent produces a Design Specification for any PBI with frontend scope (skipped for backend-only PBIs and `minor` tier PBIs)
 4. **Human checkpoint** — human approves design before engineering begins
-5. **Architecture** — ADRs and flow descriptors produced for each PBI
+5. **Architecture** — ADRs and flow descriptors produced for each PBI (flow descriptors optional for `minor` tier)
 6. **Human checkpoint** — human approves architecture
 7. **Implementation** — Frontend and backend agents implement against the approved design and architecture
-8. **Security review** — inline, two passes (design + implementation)
+8. **Security review** — inline, two passes (design + implementation); `minor` tier uses a combined single pass
 9. **Testing** — Test agent writes step definitions from `.feature` files
-10. **Independent review** — separate agent reviews code against guidelines
+10. **Independent review** — separate agent reviews code against guidelines; `minor` tier uses a combined security+review pass
 11. **Human checkpoint** — human reviews escalations only
-12. **State update** — State Update Agent rewrites `Current State` in this file
+12. **State update** — State Update Agent rewrites `Current State` in this file once all PBIs in the increment are complete
 13. **Validation** — increment validated against original intent
 14. **State update** — State Update Agent rewrites `Current State` in this file again after increment is accepted
 
@@ -78,55 +78,7 @@ Determine what you're being asked to do, then read the corresponding guideline f
 
 **To start a new increment:** Tell Claude: "Start a new increment: [your goal]"
 
-**PBI status:**
-- `PBI-001` ✅ Complete
-- `PBI-002` ✅ Complete
-- `PBI-003` ✅ Complete
-- `PBI-004` ✅ Complete
-- `PBI-005` ✅ Complete
-- `PBI-006` ✅ Complete
-- `PBI-007` ✅ Complete
-- `PBI-008` ✅ Complete
-- `PBI-009` ✅ Complete
-- `PBI-010` ✅ Complete
-- `PBI-011` ✅ Complete
-- `PBI-012` ✅ Complete
-- `PBI-013` ✅ Complete — character sheet styles and styled nav link
-- `PBI-014` ✅ Complete — trait score input width widened to prevent clipping
-- `PBI-015` ✅ Complete — slot trackers fill/empty as sequential gauges via `gaugeToggle`
-- `PBI-016` ✅ Complete — Class Feature section moved below two-column grid for full width
-- `PBI-017` ✅ Complete — backend parses `STARTING HIT POINTS` at ingestion into `hpSlotCount`; frontend wires `hpSolidCount` through context into `DamageHealthSection`
-- `PBI-018` ✅ Complete — `extractDomains` fixed to capture `<a>` link text instead of stopping at first HTML tag
-- `PBI-019` ✅ Complete — experience lines split into separate name (text) and modifier (number) fields; `ExperienceEntry` type, reducer, hook, component, and CSS updated
-- `PBI-020` ✅ Complete — nav restructured into primary row (Compendium + Character Sheet buttons with diamond decorations) and secondary row (SRD category links); route-aware open/closed state
-- `PBI-021` ✅ Complete — character sheet identity row (`ClassHeader`) and traits row (`TraitsSection`) moved to full-width rows above the two-column grid; traits grid changed to `repeat(6, 1fr)`
-- `PBI-022` ✅ Complete — damage thresholds rendered as inline single row with two inputs; `severe` field removed from `DamageThresholds` state
-- `PBI-023` ✅ Complete — identity bar grid changed from `1fr 1fr` to `repeat(3, 1fr)`; responsive overrides: 2 cols at ≤768px, 1 col at ≤480px
-
-**Feature files:** All complete ✅ (`dev-flow/product/`)
-- `PBI-001-security-baseline.feature` ✅
-- `PBI-002-backend-service-layer.feature` ✅
-- `PBI-003-backend-test-infrastructure.feature` ✅
-- `PBI-004-frontend-typescript-migration.feature` ✅
-- `PBI-005-frontend-architecture.feature` ✅
-- `PBI-006-frontend-test-infrastructure.feature` ✅
-- `PBI-007-multiword-item-navigation.feature` ✅
-- `PBI-008-character-sheet-foundation.feature` ✅
-- `PBI-009-character-sheet-class-identity.feature` ✅
-- `PBI-010-character-sheet-traits-defence.feature` ✅
-- `PBI-011-character-sheet-health-hope-gold.feature` ✅
-- `PBI-012-character-sheet-weapons-armor.feature` ✅
-- `PBI-013-character-sheet-styles.feature` ✅
-- `PBI-014-trait-input-width.feature` ✅
-- `PBI-015-slot-tracker-gauge-behaviour.feature` ✅
-- `PBI-016-class-feature-full-width.feature` ✅
-- `PBI-017-class-hp-slot-count.feature` ✅
-- `PBI-018-domain-badges-fix.feature` ✅
-- `PBI-019-experience-name-and-modifier.feature` ✅
-- `PBI-020-nav-compendium-dropdown.feature` ✅
-- `PBI-021-character-sheet-identity-traits-layout.feature` ✅
-- `PBI-022-damage-thresholds-inline.feature` ✅
-- `PBI-023-identity-bar-three-column.feature` ✅
+**Full PBI history, feature file list, and accepted ADR index:** `dev-flow/HISTORY.md`
 
 **Key constraints:**
 - Step-def method naming convention (`should_/when_`) is established as exempt for BDD step definition methods (applies only to `@Test` JUnit methods).
@@ -156,23 +108,7 @@ Determine what you're being asked to do, then read the corresponding guideline f
 - `TD-003` ✅ Resolved — Playwright XSS assertion implemented in PBI-009 step defs (`page.on('dialog', ...)`)
 - `TD-004` P3 — Migrate data-fetching hooks to React Query
 
-**Accepted ADRs:**
-- `ADR-001-spring-security-admin-protection.md` — Spring Security HTTP Basic for admin endpoints
-- `ADR-002-html-content-sanitisation.md` — Jsoup `Safelist.basic()` sanitisation on ingest
-- `ADR-003-cucumber-acceptance-testing.md` — Cucumber JVM 7.x for backend acceptance tests
-- `ADR-004-vitest-component-testing.md` — Vitest 3.x + React Testing Library for frontend component tests
-- `ADR-005-playwright-cucumber-e2e.md` — Playwright + Cucumber JS for frontend e2e acceptance tests
-- `ADR-006-typescript-compiler-configuration.md` — strict: true tsconfig for frontend TypeScript
-- `ADR-007-cra-typescript-integration.md` — CRA used for PBI-004; superseded by ADR-009
-- `ADR-008-type-strategy-third-party-deps.md` — @types/react@^18.3, @types/react-dom@^18.3
-- `ADR-009-vite-migration.md` — Vite replaces CRA; custom SCSS tilde-fix plugin; `server.port: 3000`
-- `ADR-010-api-service-layer-and-hooks.md` — srdApi.ts service layer; useSrdTypes + useSrdSearch hooks; zero fetch calls in components
-- `ADR-011-react-router-url-navigation.md` — BrowserRouter in index.tsx; /:type/:filename route; DetailRoute uses fetchItemBySlug (GET /api/srd/{slug}) not search
-- `ADR-012-character-sheet-state-management.md` — React Context + useReducer scoped to character-sheet feature; approved 2026-05-14
-- `ADR-013-weapon-armor-srd-item-types.md` — WEAPONS/ARMOR as structured SrdItem types in srd.json; HTML-parsing amendment approved 2026-05-14
-- `ADR-014-class-hp-slot-count.md` — `hpSlotCount` parsed from CLASSES content at ingestion, stored as nullable `Integer` on `SrdItem`; approved 2026-05-14
-
-**Last updated:** 2026-05-15 — identity bar compact layout increment (PBI-023) accepted; awaiting next increment statement
+**Last updated:** 2026-05-15 — identity bar compact layout increment (PBI-023) accepted; dev-flow retrospective improvements applied
 
 ---
 
@@ -187,6 +123,6 @@ These apply regardless of what you've been asked to do:
 5. **TypeScript only.** No new `.js` or `.jsx` files. All new frontend code is `.ts` or `.tsx`.
 6. **Tests are not optional.** Every PBI must have passing step definitions for all its `@backend` and `@frontend` scenarios before it is considered done.
 7. **ADRs before implementation.** Any decision that meets the ADR trigger criteria in `dev-flow/engineering/architecture/architecture-guidelines.md` must be documented and acknowledged before the implementation begins.
-8. **Security agent runs twice.** Once at design time (after architecture, before implementation) and once after implementation (before independent review). Both passes are required for any PBI touching auth, endpoints, user input, or data persistence.
-9. **State Update Agent runs automatically.** After every PBI passes independent review, and after every accepted increment, the State Update Agent must update the `Current State` section of this file. Do not skip this step — it is how the next session knows where to start.
+8. **Security agent runs twice.** Once at design time (after architecture, before implementation) and once after implementation (before independent review). Both passes are required for any PBI touching auth, endpoints, user input, or data persistence. `minor` tier PBIs use a single combined security+review pass — see `dev-flow/product/product-track-guidelines.md`.
+9. **State Update Agent runs once per increment, not per PBI.** It runs after all PBIs in the increment pass independent review (on the increment branch), and again after the human accepts the increment (docs branch). Do not run it after every individual PBI. This is how the next session knows where to start.
 10. **Nothing is ever committed directly to `main`.** All changes — code, ADRs, feature files, `CLAUDE.md`, dev-flow documentation — reach `main` through a branch and a pull request. See `dev-flow/engineering/version-control-guidelines.md` for branch naming conventions and the full branching model.

--- a/dev-flow/HISTORY.md
+++ b/dev-flow/HISTORY.md
@@ -1,0 +1,88 @@
+# Dev-Flow History
+
+This file records completed work. It exists to keep `CLAUDE.md` lean — only active, forward-looking state belongs there.
+
+---
+
+## Completed PBIs
+
+| PBI | Title / notes |
+|---|---|
+| `PBI-001` | Security baseline — Spring Security admin protection, Jsoup sanitisation, security headers, CORS consolidation |
+| `PBI-002` | Backend service layer — SrdService extracted from controller; SrdRepository introduced |
+| `PBI-003` | Backend test infrastructure — Cucumber JVM 7.x + JUnit 5 acceptance test harness |
+| `PBI-004` | Frontend TypeScript migration — CRA-based TypeScript baseline (superseded by ADR-009 in PBI-005) |
+| `PBI-005` | Frontend architecture — Vite migration (ADR-009); srdApi.ts service layer + useSrdTypes/useSrdSearch hooks (ADR-010); React Router URL navigation (ADR-011) |
+| `PBI-006` | Frontend test infrastructure — Vitest + RTL component tests; Playwright + Cucumber JS e2e harness |
+| `PBI-007` | Multiword item navigation — slugified URL routing for multi-word SRD item names |
+| `PBI-008` | Character sheet foundation — layout scaffold, CharacterContext + useReducer state (ADR-012) |
+| `PBI-009` | Character sheet class identity — ClassHeader; useSrdClasses/useSrdSubclasses hooks; XSS e2e assertion (TD-003 resolved) |
+| `PBI-010` | Character sheet traits & defence — TraitsSection (6 trait scores); DefenceSection |
+| `PBI-011` | Character sheet health, hope & gold — DamageHealthSection; HP/stress/hope slot gauges via `gaugeToggle` |
+| `PBI-012` | Character sheet weapons & armor — WeaponsSection; ArmorSection; WEAPONS/ARMOR HTML parsing (ADR-013) |
+| `PBI-013` | Character sheet styles — polished SCSS; styled nav link |
+| `PBI-014` | Trait input width — widened trait score input to prevent clipping |
+| `PBI-015` | Slot tracker gauge behaviour — `gaugeToggle` fills 0..N on click N; empties on re-click of last filled |
+| `PBI-016` | Class feature full width — ClassFeatureSection moved below two-column grid |
+| `PBI-017` | Class HP slot count — `hpSlotCount` parsed from CLASSES content at ingestion (ADR-014); `hpSolidCount` wired through context into DamageHealthSection |
+| `PBI-018` | Domain badges fix — `extractDomains` fixed to capture `<a>` link text; domain names now come from link text not plain text nodes |
+| `PBI-019` | Experience name and modifier — each experience row split into name (text) + modifier (number) fields; ExperienceEntry type, reducer, hook, component, CSS updated |
+| `PBI-020` | Nav compendium dropdown — primary row (Compendium toggle + Character Sheet) and secondary row (SRD category links); route-aware open/closed state |
+| `PBI-021` | Character sheet identity and traits layout — ClassHeader and TraitsSection moved to full-width rows above the two-column grid; traits grid changed to `repeat(6, 1fr)` |
+| `PBI-022` | Damage thresholds inline — thresholds rendered as inline single row with two inputs; `severe` field removed from DamageThresholds state |
+| `PBI-023` | Identity bar three-column — identity bar grid changed from `1fr 1fr` to `repeat(3, 1fr)`; responsive overrides: 2 cols at ≤768px, 1 col at ≤480px |
+
+---
+
+## Completed Feature Files
+
+All feature files live in `dev-flow/product/`.
+
+| File | Status |
+|---|---|
+| `PBI-001-security-baseline.feature` | ✅ |
+| `PBI-002-backend-service-layer.feature` | ✅ |
+| `PBI-003-backend-test-infrastructure.feature` | ✅ |
+| `PBI-004-frontend-typescript-migration.feature` | ✅ |
+| `PBI-005-frontend-architecture.feature` | ✅ |
+| `PBI-006-frontend-test-infrastructure.feature` | ✅ |
+| `PBI-007-multiword-item-navigation.feature` | ✅ |
+| `PBI-008-character-sheet-foundation.feature` | ✅ |
+| `PBI-009-character-sheet-class-identity.feature` | ✅ |
+| `PBI-010-character-sheet-traits-defence.feature` | ✅ |
+| `PBI-011-character-sheet-health-hope-gold.feature` | ✅ |
+| `PBI-012-character-sheet-weapons-armor.feature` | ✅ |
+| `PBI-013-character-sheet-styles.feature` | ✅ |
+| `PBI-014-trait-input-width.feature` | ✅ |
+| `PBI-015-slot-tracker-gauge-behaviour.feature` | ✅ |
+| `PBI-016-class-feature-full-width.feature` | ✅ |
+| `PBI-017-class-hp-slot-count.feature` | ✅ |
+| `PBI-018-domain-badges-fix.feature` | ✅ |
+| `PBI-019-experience-name-and-modifier.feature` | ✅ |
+| `PBI-020-nav-compendium-dropdown.feature` | ✅ |
+| `PBI-021-character-sheet-identity-traits-layout.feature` | ✅ |
+| `PBI-022-damage-thresholds-inline.feature` | ✅ |
+| `PBI-023-identity-bar-three-column.feature` | ✅ |
+
+---
+
+## Accepted ADRs
+
+Full ADR documents live in `dev-flow/engineering/architecture/`.
+
+| ADR | Decision |
+|---|---|
+| `ADR-001-spring-security-admin-protection.md` | Spring Security HTTP Basic for admin endpoints |
+| `ADR-002-html-content-sanitisation.md` | Jsoup `Safelist.basic()` sanitisation on ingest |
+| `ADR-003-cucumber-acceptance-testing.md` | Cucumber JVM 7.x for backend acceptance tests |
+| `ADR-004-vitest-component-testing.md` | Vitest 3.x + React Testing Library for frontend component tests |
+| `ADR-005-playwright-cucumber-e2e.md` | Playwright + Cucumber JS for frontend e2e acceptance tests |
+| `ADR-006-typescript-compiler-configuration.md` | `strict: true` tsconfig for frontend TypeScript |
+| `ADR-007-cra-typescript-integration.md` | CRA used for PBI-004; superseded by ADR-009 |
+| `ADR-008-type-strategy-third-party-deps.md` | `@types/react@^18.3`, `@types/react-dom@^18.3` |
+| `ADR-009-vite-migration.md` | Vite replaces CRA; custom SCSS tilde-fix plugin; `server.port: 3000` |
+| `ADR-010-api-service-layer-and-hooks.md` | `srdApi.ts` service layer; `useSrdTypes` + `useSrdSearch` hooks; zero fetch calls in components |
+| `ADR-011-react-router-url-navigation.md` | BrowserRouter in `index.tsx`; `/:type/:filename` route; DetailRoute uses `fetchItemBySlug` |
+| `ADR-012-character-sheet-state-management.md` | React Context + useReducer scoped to character-sheet feature |
+| `ADR-013-weapon-armor-srd-item-types.md` | WEAPONS/ARMOR as structured SrdItem types in `srd.json`; HTML-parsing amendment approved |
+| `ADR-014-class-hp-slot-count.md` | `hpSlotCount` parsed from CLASSES content at ingestion, stored as nullable `Integer` on `SrdItem` |

--- a/dev-flow/design/ux-design-guidelines.md
+++ b/dev-flow/design/ux-design-guidelines.md
@@ -46,8 +46,9 @@ A PBI triggers the Design Agent if it has **any** of the following:
 - Pure backend PBIs (all scenarios tagged `@backend` only)
 - Infrastructure PBIs with no user-visible surface
 - Bug fixes that restore a previously approved design (the original spec is already the reference)
+- **`minor` tier PBIs** — CSS/layout-only changes with no new components, no new interactions, and no new copy. The complexity tier is declared in the feature file's `# Complexity:` comment.
 
-When skipping, the Design Agent notes: `"Design stage skipped — no frontend scope in PBI-XXX."` and the Architecture Agent proceeds.
+When skipping, the Design Agent notes: `"Design stage skipped — [reason: no frontend scope / minor tier / bug fix restoring prior design] in PBI-XXX."` and the Architecture Agent proceeds.
 
 ---
 

--- a/dev-flow/engineering/review/independent-review-guidelines.md
+++ b/dev-flow/engineering/review/independent-review-guidelines.md
@@ -4,6 +4,24 @@ This document defines how the Independent Review Agent operates — its context 
 
 ---
 
+## Minor Tier: Combined Security + Review Pass
+
+For PBIs classified as `minor` (declared in the `# Complexity:` comment at the top of the feature file), the Security Agent Pass 2 and the Independent Review are combined into a single pass. The same agent performs both the security check and the code review in one report.
+
+The combined pass uses the standard review report format but adds a **Security Check** section between Summary and Blockers:
+
+```
+## Security Check (combined pass — minor tier)
+
+[Brief assessment: does this change introduce any new security surface? For a genuine minor-tier change this should be short: "No new endpoints, no user input, no auth surface — no security concerns." If a concern exists, promote it to a Blocker.]
+```
+
+All other checks are identical to a standard review. The isolation principle still applies — the combined pass agent must not carry over implementation session context.
+
+**If the combined pass agent finds that the PBI is not actually `minor`** (e.g., the implementation introduced a new type, a new pattern, or a new dependency not declared in the feature file), it escalates immediately: the tier must be upgraded, a Security Pass 1 review conducted, and the independent review re-run at the correct tier.
+
+---
+
 ## The Isolation Principle
 
 The Independent Review Agent is deliberately isolated from the Implementation Agents. It does not share context, conversation history, or reasoning with the agents that produced the code. This is not a limitation — it is the point.

--- a/dev-flow/engineering/state/state-update-guidelines.md
+++ b/dev-flow/engineering/state/state-update-guidelines.md
@@ -6,13 +6,15 @@ The State Update Agent runs automatically at two points in the workflow and has 
 
 ## When It Runs
 
-### Trigger 1: After a PBI is completed (on the increment branch)
+### Trigger 1: After all PBIs in an increment are complete (on the increment branch)
 
-A PBI is complete when:
-- The Independent Review Agent has passed it (no remaining Blockers)
-- All `@backend` and `@frontend` acceptance scenarios for that PBI are passing in CI
+The State Update Agent runs **once per increment**, not after every individual PBI. It runs when:
+- All PBIs in the increment have passed Independent Review (no remaining Blockers on any PBI)
+- All `@backend` and `@frontend` acceptance scenarios for the increment are passing
 
 At this point the State Update Agent runs, updates `CLAUDE.md`, and **commits the change to the current increment branch**. This update is included in the PR and reaches `main` when the branch merges — it is not committed to `main` directly.
+
+If an increment has only one PBI, this trigger fires when that PBI is complete. For multi-PBI increments, do not run the State Update Agent after each individual PBI — run it once when all PBIs are done.
 
 ### Trigger 2: After an increment is accepted (docs branch)
 
@@ -73,7 +75,7 @@ The agent edits **only the `Current State` section** of `CLAUDE.md`. It does not
 
 **Accepted ADRs:** [List of accepted ADR filenames, or "None yet"]
 
-**Last updated:** YYYY-MM-DD after [trigger description, e.g. "PBI-002 completed"]
+**Last updated:** YYYY-MM-DD after [trigger description, e.g. "all PBIs complete" or "increment accepted"]
 ```
 
 ### Stage descriptions
@@ -86,10 +88,9 @@ Use exactly one of these for the `Stage` field:
 | `Scenarios approved — Architecture Agent running` | Human approved scenarios; architecture work in progress |
 | `Awaiting architecture approval — ADRs ready for human review` | Architecture Agent has produced ADRs/flow descriptors; human has not yet approved |
 | `Architecture approved — Implementation in progress` | Human approved architecture; implementation underway |
-| `Implementation complete — Security review in progress` | Implementation done; Security Agent Pass 2 running |
+| `Implementation complete — Security review in progress` | Implementation done; Security Agent Pass 2 running (or combined pass for `minor` tier) |
 | `Security approved — Independent review in progress` | Security Agent approved; Independent Review Agent running |
-| `PBI-XXX complete — PBI-YYY starting` | A PBI just finished and the next is beginning |
-| `All PBIs complete — Increment validation in progress` | All PBIs done; Validation Agent running |
+| `All PBIs complete — Increment validation in progress` | All PBIs done and State Update Agent has run on the branch; Validation Agent running |
 | `Increment accepted — awaiting next increment statement` | Increment validated and accepted; no new increment started yet |
 
 ---

--- a/dev-flow/engineering/validation/increment-validation-guidelines.md
+++ b/dev-flow/engineering/validation/increment-validation-guidelines.md
@@ -11,10 +11,9 @@ This is distinct from code review (was it built correctly?) and test coverage (d
 The Increment Validation Agent runs after:
 
 1. All Blockers from the Independent Review Agent have been resolved.
-2. All acceptance tests pass in CI.
-3. The increment has been deployed to a representative environment (staging or equivalent).
+2. All acceptance tests pass (locally or in CI — wherever the full test suite can be run against the assembled application).
 
-Validation does **not** run against local or developer environments. It requires the assembled, deployed product.
+Validation does **not** require a deployed staging environment. The test suite is the primary validation mechanism. Step 3 (exploratory walkthrough) is optional — it should only be performed when there is a specific concern that automated tests do not cover, and the human has explicitly requested it or the agent has identified a gap.
 
 ---
 
@@ -48,9 +47,11 @@ The agent reads the CI test results for all scenarios tagged to this increment. 
 - **Some scenarios fail** → these represent undelivered functionality. Each failure is described in plain language (not as a test error — as a product behaviour that is missing or broken).
 - **Scenarios skipped (`@wip`)** → these represent known gaps. Each is assessed against the increment intent: is this gap acceptable for this increment, or does it leave the stated goal partially unmet?
 
-### Step 3: Exploratory validation
+### Step 3: Exploratory validation (optional)
 
-For each backlog item in the increment, the agent performs a structured walkthrough of the primary user flow against the deployed application. This is not a test re-run — it is a product-perspective check that goes beyond what automated tests assert:
+This step is only performed when the agent has identified a specific concern that automated tests do not cover, or when the human has explicitly requested it. It is not a default step.
+
+When performed, the agent conducts a structured walkthrough of the primary user flow:
 
 - Does the feature feel complete? Are there obvious missing pieces a scenario didn't capture?
 - Are error states handled gracefully from the user's perspective (not just technically correct)?
@@ -59,6 +60,8 @@ For each backlog item in the increment, the agent performs a structured walkthro
 - Are there UI states that are broken, confusing, or incomplete that are not covered by a scenario?
 
 Findings from this step are reported as **Observations** — they are not pass/fail, but they inform the human's decision and feed into the next increment's backlog.
+
+If this step is skipped, the Validation Report notes: `"Exploratory walkthrough: not performed — no specific concerns identified beyond automated test coverage."`
 
 ### Step 4: Produce the validation report
 
@@ -71,7 +74,7 @@ Findings from this step are reported as **Observations** — they are not pass/f
 
 **Increment:** [Increment name / goal statement]
 **Date:** YYYY-MM-DD
-**Environment:** [Staging URL or environment name]
+**Test run:** [local / CI — where the acceptance suite was run]
 **Backlog items:** PBI-XXX, PBI-YYY, ...
 
 ---

--- a/dev-flow/product/acceptance-scenarios.md
+++ b/dev-flow/product/acceptance-scenarios.md
@@ -111,6 +111,7 @@ Use tags to classify scenarios. The test runner uses these to select what to exe
 | `@frontend` | Executed by Playwright + Cucumber (React) |
 | `@backend` | Executed by Cucumber + JUnit 5 (Java) |
 | `@security` | Security-relevant scenario — always included in security review |
+| `@performance` | Non-functional scenario asserting a timing or responsiveness constraint (e.g. render time, search debounce). Optional — use only when a measurable acceptance criterion exists. |
 | `@wip` | Work in progress — excluded from CI until ready |
 
 A scenario can carry multiple tags:
@@ -118,6 +119,28 @@ A scenario can carry multiple tags:
 @smoke @frontend
 Scenario: Successful login redirects to dashboard
 ```
+
+---
+
+## Complexity Tier Comment
+
+Every feature file must declare the PBI's complexity tier at the top, before the `Feature:` block. This tells all downstream engineering agents which stages to run.
+
+```gherkin
+# Complexity: minor | standard | significant
+
+Feature: ...
+```
+
+If the Acceptance Scenario Agent upgrades the tier from what was assigned at breakdown, it appends the reason:
+
+```gherkin
+# Complexity: standard — upgraded from minor: introduces new ExperienceEntry type
+
+Feature: ...
+```
+
+See `dev-flow/product/product-track-guidelines.md` for tier definitions and the stages each tier skips.
 
 ---
 
@@ -210,3 +233,4 @@ Before engineering begins, confirm the scenarios for each backlog item:
 - [ ] Scenario steps are written in user/product language (no implementation leakage)
 - [ ] Concrete values are used (no abstract placeholders)
 - [ ] The scope feels right — nothing missing, nothing out of scope
+- [ ] The complexity tier comment is present at the top of the file and feels right — `minor` is only appropriate for pure CSS/layout changes with no new types, patterns, or dependencies

--- a/dev-flow/product/product-track-guidelines.md
+++ b/dev-flow/product/product-track-guidelines.md
@@ -48,6 +48,9 @@ PBI-XXX: [Title — imperative, concrete, user-facing]
 
 Type: Feature | Bug | Tech enabler | Security | Debt
 
+Complexity: minor | standard | significant
+  [Brief rationale — see tier definitions below]
+
 User story:
   As a [role],
   I want to [do something specific],
@@ -67,6 +70,20 @@ Estimated size: XS | S | M | L | XL
 Open questions:
   - [Anything that needs a product decision before scenarios can be written]
 ```
+
+### Complexity Tier Definitions
+
+Every PBI is assigned a complexity tier at breakdown time. The tier determines which engineering stages run. When in doubt, choose the higher tier — it is always safe to do more; it is not always safe to do less.
+
+| Tier | Criteria | Stages skipped |
+|---|---|---|
+| `minor` | CSS/layout-only changes; no new types; no new patterns; no backend changes; no new dependencies; all changes confined to existing components | Design Specification; flow descriptor; Security Pass 1 (design-time); Security Pass 2 and Independent Review merged into a single combined pass |
+| `standard` | New components or hooks following existing patterns; minor backend changes; changes within an existing feature | Nothing skipped — full flow |
+| `significant` | New architectural patterns; new dependencies; backend data model changes; new endpoints; auth/authz surface; cross-feature changes | Nothing skipped — full flow with heightened security attention |
+
+**The `minor` tier is not a shortcut for "small".** A small change that introduces a new type, a new pattern, or a new dependency is `standard`. The test: could this change cause a regression in untouched code? If yes, it is not `minor`.
+
+**The Acceptance Scenario Agent may upgrade the tier.** If writing complete scenarios reveals complexity not apparent at breakdown time, the agent upgrades the tier and notes the reason. Engineering stages follow the final tier assigned by the Acceptance Scenario Agent.
 
 ### Bug PBI Format
 
@@ -271,6 +288,15 @@ open questions. These must be answered before the feature file is complete.
 The scenario gap list is escalated to the human before engineering begins.
 
 **Tags are applied correctly.** Every scenario carries the appropriate tags from the tagging scheme in `product/acceptance-scenarios.md`. The agent does not omit security tags for scenarios that involve auth, permissions, or user input.
+
+**Confirms or upgrades the complexity tier.** The agent reviews the tier assigned at breakdown and confirms it or upgrades it based on what the scenarios reveal. It documents the final tier and any upgrade rationale at the top of the feature file as a comment:
+
+```gherkin
+# Complexity: minor
+# (or: Complexity: standard — upgraded from minor: introduces new ExperienceEntry type)
+```
+
+This comment is the signal to all downstream engineering agents about which stages to run.
 
 ### Human Checkpoint
 


### PR DESCRIPTION
## Summary

Applies the improvements identified in the AI-native dev-flow retrospective. No production code changed — all changes are to dev-flow documentation and `CLAUDE.md`.

- **PBI complexity tier** (`minor` / `standard` / `significant`) added to the product track. `minor` tier PBIs skip the Design Spec, flow descriptor, and merge the two security+review passes into one. Tier is declared as a comment at the top of each feature file. Downstream guidelines (design, review) updated to honour the tier.
- **`dev-flow/HISTORY.md` created** — holds the completed PBI list, feature file index, and accepted ADR index. `CLAUDE.md` Current State trimmed to active-only content; will stay lean as the project grows.
- **Validation guideline fixed** — removes the mandatory deployed-environment and browser-walkthrough requirements. Test suite pass = validation. Step 3 (exploratory walkthrough) is now optional and only runs when there is a specific gap not covered by tests.
- **State Update Agent batched** — runs once per increment (after all PBIs complete) instead of after every individual PBI. Removes 3-4 redundant state update passes per multi-PBI increment.
- **`@performance` tag** added to the scenario tag table for non-functional timing/responsiveness acceptance criteria.

## Test plan

- [ ] Read `CLAUDE.md` - Current State section is visibly shorter; hard rules 8 and 9 reflect the changes
- [ ] Read `dev-flow/HISTORY.md` - completed PBI list, feature files, and ADRs are all present
- [ ] Read `dev-flow/product/product-track-guidelines.md` - complexity tier section present with tier table and Acceptance Scenario Agent upgrade rules
- [ ] Read `dev-flow/product/acceptance-scenarios.md` - `@performance` tag in table, complexity tier comment section present, checklist updated
- [ ] Read `dev-flow/design/ux-design-guidelines.md` - `minor` tier listed as a skip condition
- [ ] Read `dev-flow/engineering/review/independent-review-guidelines.md` - combined pass section present at top
- [ ] Read `dev-flow/engineering/validation/increment-validation-guidelines.md` - Step 3 marked optional; deployed environment no longer required
- [ ] Read `dev-flow/engineering/state/state-update-guidelines.md` - Trigger 1 now describes per-increment (not per-PBI) firing

Generated with Claude Code
